### PR TITLE
Switch useTextureView to default to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,14 +644,16 @@ textTracks={[
 Platforms: Android ExoPlayer, iOS
 
 #### useTextureView
-Output to a TextureView instead of the default SurfaceView. In general, you will want to use SurfaceView because it is more efficient and provides better performance. However, SurfaceViews has two limitations:
+Controls whether to output to a TextureView or SurfaceView.
+
+SurfaceView is more efficient and provides better performance but has two limitations:
 * It can't be animated, transformed or scaled
 * You can't overlay multiple SurfaceViews
 
 useTextureView can only be set at same time you're setting the source.
 
-* **false (default)** - Use a SurfaceView
-* **true** - Use a TextureView
+* **true (default)** - Use a TextureView
+* **false** - Use a SurfaceView
 
 Platforms: Android ExoPlayer
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -215,7 +215,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.setFullscreen(fullscreen);
     }
 
-    @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = false)
+    @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = true)
     public void setUseTextureView(final ReactExoplayerView videoView, final boolean useTextureView) {
         videoView.setUseTextureView(useTextureView);
     }


### PR DESCRIPTION
A number of people run into SurfaceView layering issues. It seems better to default to the more compatible option and let people reconfigure if they need the extra SurfaceView performance.