### PR TITLE
fix: check for ios url query encoding

### DIFF
--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -299,7 +299,7 @@ enum RCTVideoUtils {
         var asset:AVURLAsset!
         let bundlePath = Bundle.main.path(forResource: source.uri, ofType: source.type) ?? ""
         let url = source.isNetwork || source.isAsset
-        ? URL(string: source.uri ?? "")
+        ? URL(string: source.uri?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")
         : URL(fileURLWithPath: bundlePath)
         let assetOptions:NSMutableDictionary! = NSMutableDictionary()
         


### PR DESCRIPTION
This adds url encoding for ios and fixes an old [issue #1566](https://github.com/react-native-video/react-native-video/issues/1566). Loading a video with spaces in the URL on a physical iOS device fails and results in endless spinner

#### Example
`
      <Video
        source={{
          uri: 'https://mwcdn.inthecloud.ai/video/6fd96c55-190c-420c-8b0d-ca5fca4f980bMOBILITY LESSON 1_500mb_a641540df031561e2833e0436c1e411f.mp4',
        }}
        style={{
          height: 200,
          width: 200,
        }}
      />
`

#### Device
- iPhone 6s
- iOS 13.7

