### PR TITLE
Sideload audio

### DIFF
--- a/android/src/main/java/com/brentvatne/common/api/SideLoadedAudioTrack.kt
+++ b/android/src/main/java/com/brentvatne/common/api/SideLoadedAudioTrack.kt
@@ -1,0 +1,34 @@
+package com.brentvatne.common.api
+
+import android.net.Uri
+import com.brentvatne.common.toolbox.ReactBridgeUtils
+import com.facebook.react.bridge.ReadableMap
+
+/**
+* Class representing a sideLoaded audio track from application
+*/
+class SideLoadedAudioTrack {
+   var url: Uri = Uri.EMPTY
+   var title: String? = null
+   var language: String? = null
+   var sampleMimeType: String? = null
+
+   companion object {
+       val SIDELOAD_AUDIO_TRACK_URL = "url"
+       val SIDELOAD_AUDIO_TRACK_TITLE = "title"
+       val SIDELOAD_AUDIO_TRACK_LANGUAGE = "language"
+       val SIDELOAD_AUDIO_TRACK_SAMPLE_MIME_TYPE = "sampleMimeType"
+
+       fun parse(src: ReadableMap?): SideLoadedAudioTrack {
+            val sideLoadedAudioTrack = SideLoadedAudioTrack()
+            if (src == null) {
+                return sideLoadedAudioTrack
+            }
+            sideLoadedAudioTrack.url = Uri.parse(ReactBridgeUtils.safeGetString(src, SIDELOAD_AUDIO_TRACK_URL, ""))
+            sideLoadedAudioTrack.title = ReactBridgeUtils.safeGetString(src, SIDELOAD_AUDIO_TRACK_TITLE, "")
+            sideLoadedAudioTrack.language = ReactBridgeUtils.safeGetString(src, SIDELOAD_AUDIO_TRACK_LANGUAGE, "")
+            sideLoadedAudioTrack.sampleMimeType = ReactBridgeUtils.safeGetString(src, SIDELOAD_AUDIO_TRACK_SAMPLE_MIME_TYPE, "")
+            return sideLoadedAudioTrack
+        }
+    }
+}

--- a/android/src/main/java/com/brentvatne/common/api/SideLoadedAudioTrackList.kt
+++ b/android/src/main/java/com/brentvatne/common/api/SideLoadedAudioTrackList.kt
@@ -1,0 +1,32 @@
+package com.brentvatne.common.api
+
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+
+/**
+ * Class representing a list of sideLoaded audio tracks from application
+ * Do you use player import in this class
+ */
+class SideLoadedAudioTrackList {
+    var tracks = ArrayList<SideLoadedAudioTrack>()
+
+    /** return true if this and src are equals  */
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is SideLoadedAudioTrackList) return false
+        return tracks == other.tracks
+    }
+
+    companion object {
+        fun parse(src: ReadableArray?): SideLoadedAudioTrackList? {
+            if (src == null) {
+                return null
+            }
+            val sideLoadedAudioTrackList = SideLoadedAudioTrackList()
+            for (i in 0 until src.size()) {
+                val audioTrack: ReadableMap = src.getMap(i)
+                sideLoadedAudioTrackList.tracks.add(SideLoadedAudioTrack.parse(audioTrack))
+            }
+            return sideLoadedAudioTrackList
+        }
+    }
+}

--- a/android/src/main/java/com/brentvatne/common/api/SideLoadedAudioTrackList.kt
+++ b/android/src/main/java/com/brentvatne/common/api/SideLoadedAudioTrackList.kt
@@ -23,8 +23,10 @@ class SideLoadedAudioTrackList {
             }
             val sideLoadedAudioTrackList = SideLoadedAudioTrackList()
             for (i in 0 until src.size()) {
-                val audioTrack: ReadableMap = src.getMap(i)
-                sideLoadedAudioTrackList.tracks.add(SideLoadedAudioTrack.parse(audioTrack))
+                val audioTrack: ReadableMap? = src.getMap(i)
+                audioTrack?.let {
+                    sideLoadedAudioTrackList.tracks.add(SideLoadedAudioTrack.parse(it))
+                }
             }
             return sideLoadedAudioTrackList
         }

--- a/android/src/main/java/com/brentvatne/common/api/Source.kt
+++ b/android/src/main/java/com/brentvatne/common/api/Source.kt
@@ -90,6 +90,8 @@ class Source {
      */
     var sideLoadedTextTracks: SideLoadedTextTrackList? = null
 
+    var sideLoadedAudioTracks: SideLoadedAudioTrackList? = null
+
     override fun hashCode(): Int = Objects.hash(uriString, uri, startPositionMs, cropStartMs, cropEndMs, extension, metadata, headers)
 
     /** return true if this and src are equals  */
@@ -105,6 +107,7 @@ class Source {
                 contentStartTime == other.contentStartTime &&
                 cmcdProps == other.cmcdProps &&
                 sideLoadedTextTracks == other.sideLoadedTextTracks &&
+                sideLoadedAudioTracks == other.sideLoadedAudioTracks &&
                 adsProps == other.adsProps &&
                 minLoadRetryCount == other.minLoadRetryCount &&
                 isLocalAssetFile == other.isLocalAssetFile &&
@@ -179,6 +182,7 @@ class Source {
         private const val PROP_SRC_ADS = "ad"
         private const val PROP_SRC_TEXT_TRACKS_ALLOW_CHUNKLESS_PREPARATION = "textTracksAllowChunklessPreparation"
         private const val PROP_SRC_TEXT_TRACKS = "textTracks"
+        private const val PROP_SRC_AUDIO_TRACKS = "audioTracks"
         private const val PROP_SRC_MIN_LOAD_RETRY_COUNT = "minLoadRetryCount"
         private const val PROP_SRC_BUFFER_CONFIG = "bufferConfig"
 
@@ -247,6 +251,7 @@ class Source {
                 }
                 source.textTracksAllowChunklessPreparation = safeGetBool(src, PROP_SRC_TEXT_TRACKS_ALLOW_CHUNKLESS_PREPARATION, true)
                 source.sideLoadedTextTracks = SideLoadedTextTrackList.parse(safeGetArray(src, PROP_SRC_TEXT_TRACKS))
+                source.sideLoadedAudioTracks = SideLoadedAudioTrackList.parse(safeGetArray(src, PROP_SRC_AUDIO_TRACKS))
                 source.minLoadRetryCount = safeGetInt(src, PROP_SRC_MIN_LOAD_RETRY_COUNT, 3)
                 source.bufferConfig = BufferConfig.parse(safeGetMap(src, PROP_SRC_BUFFER_CONFIG))
 

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -246,6 +246,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           ad: _ad,
           cmcd: _cmcd,
           textTracks: _textTracks,
+          audioTracks: resolvedSource.audioTracks,
           textTracksAllowChunklessPreparation:
             resolvedSource.textTracksAllowChunklessPreparation,
           minLoadRetryCount: _minLoadRetryCount,

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -50,6 +50,7 @@ export type VideoSrc = Readonly<{
   cmcd?: NativeCmcdConfiguration; // android
   textTracksAllowChunklessPreparation?: boolean; // android
   textTracks?: TextTracks;
+  audioTracks?: AudioTracks; // android
   ad?: AdsConfig;
   minLoadRetryCount?: Int32; // Android
   bufferConfig?: BufferConfig; // Android
@@ -89,6 +90,15 @@ type TextTracks = ReadonlyArray<
     language: string;
     type: string;
     uri: string;
+  }>
+>;
+
+type AudioTracks = ReadonlyArray<
+  Readonly<{
+    url: string;
+    title?: string;
+    language?: string;
+    sampleMimeType?: string;
   }>
 >;
 

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -39,6 +39,7 @@ export type ReactVideoSourceProperties = {
   cmcd?: Cmcd; // android
   textTracksAllowChunklessPreparation?: boolean;
   textTracks?: TextTracks;
+  audioTracks?: AudioTracks; // android
   ad?: AdConfig;
   minLoadRetryCount?: number; // Android
   bufferConfig?: BufferConfig;
@@ -208,6 +209,14 @@ export type SelectedTextTrack = Readonly<{
   type: TextTrackSelectionType;
   value?: string | number;
 }>;
+
+export type AudioTracks = {
+  url: string;
+  title?: string;
+  language?: string;
+  sampleMimeType?: string;
+}[];
+
 
 export type AudioTrackSelectionType =
   | 'system'


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
A source.audioTracks for sideload audio tracks.
I updated the patch for work on 0.77 react-native.

### Motivation
https://github.com/TheWidlarzGroup/react-native-video/issues/4374
https://github.com/TheWidlarzGroup/react-native-video/issues/3265
### Changes
Get sideload audio and merge all in one source for exoplayer, check commits.
## Test plan
It's not perfect for now, for example in my code I didn't setup language of audio in the Reactexoplayerview.java. 
In 6.8.2 I had a poster bug, when audio tracks and poster are set : Audio work, but the poster stay over the video.
I don't test in 6.9 if this is fixed, I will test.