### PR TITLE
Update "Resolves a retain cycle and memory leak involving the RCTVideo instance when using Google IMA ads in react-native-video."

### DIFF
--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -30,8 +30,14 @@
 
         func requestAds() {
             guard let _video else { return }
+            // fixes RCTVideo --> RCTIMAAdsManager --> IMAAdsLoader --> IMAAdDisplayContainer --> RCTVideo memory leak.
+            let adContainerView = UIView(frame: _video.bounds)
+            adContainerView.backgroundColor = .clear
+            adContainerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            _video.addSubview(adContainerView)
+
             // Create ad display container for ad rendering.
-            let adDisplayContainer = IMAAdDisplayContainer(adContainer: _video, viewController: _video.reactViewController())
+            let adDisplayContainer = IMAAdDisplayContainer(adContainer: adContainerView, viewController: _video.reactViewController())
 
             let adTagUrl = _video.getAdTagUrl()
             let contentPlayhead = _video.getContentPlayhead()

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -30,13 +30,8 @@
 
         func requestAds() {
             guard let _video else { return }
-            // fixes RCTVideo --> RCTIMAAdsManager --> IMAAdsLoader --> IMAAdDisplayContainer --> RCTVideo memory leak.
-            let adContainerView = UIView(frame: _video.bounds)
-            adContainerView.backgroundColor = .clear
-            _video.addSubview(adContainerView)
-
             // Create ad display container for ad rendering.
-            let adDisplayContainer = IMAAdDisplayContainer(adContainer: adContainerView, viewController: _video.reactViewController())
+            let adDisplayContainer = IMAAdDisplayContainer(adContainer: _video, viewController: _video.reactViewController())
 
             let adTagUrl = _video.getAdTagUrl()
             let contentPlayhead = _video.getContentPlayhead()


### PR DESCRIPTION
Update TheWidlarzGroup/react-native-video#4574

iOS Google IMA Ads Container Not Resizing on Fullscreen or Rotation — Fixed by Adding AutoresizingMask

After recent changes to Google IMA integration, the ad container on iOS was not resizing when the player entered/exited fullscreen or changed orientation when using custom controls.

Cause:
The adContainerView added inside requestAds() had a fixed frame without autoresizingMask, causing layout issues.

Fix:
Added:
adContainerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]

let adContainerView = UIView(frame: _video.bounds)
adContainerView.backgroundColor = .clear
adContainerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
_video.addSubview(adContainerView)
