### PR TITLE
fix(android): system controls are not hidden when going back to app

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/fragments/FullscreenVideoFragment.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/fragments/FullscreenVideoFragment.kt
@@ -56,6 +56,14 @@ class FullscreenVideoFragment(private val videoView: VideoView) : Fragment() {
     return this.container
   }
 
+  override fun onResume() {
+    super.onResume()
+
+    // System UI is re-enabled when user have exited app and go back
+    // We need to hide it again
+    hideSystemUI()
+  }
+
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 


### PR DESCRIPTION
## Summary
Hide system controls in full screen again when user go back to app