### PR TITLE
Fix/issue/4488

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -43,6 +43,7 @@ object PictureInPictureUtil {
 
         val onPictureInPictureModeChanged = Consumer<PictureInPictureModeChangedInfo> { info ->
             view.setIsInPictureInPicture(info.isInPictureInPictureMode)
+            view.setPictureInPictureMode(info.isInPictureInPictureMode)
             if (!info.isInPictureInPictureMode && activity.lifecycle.currentState == Lifecycle.State.CREATED) {
                 // when user click close button of PIP
                 if (!view.playInBackground) view.setPausedModifier(true)

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2476,6 +2476,12 @@ public class ReactExoplayerView extends FrameLayout implements
                 }
                 addView(exoPlayerView, 0, layoutParams);
             }
+            if (exoPlayerView != null) {
+                exoPlayerView.post(() -> {
+                    exoPlayerView.requestLayout();
+                    reLayout(exoPlayerView);
+                });
+            }
         }
     }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -246,6 +246,7 @@ public class ReactExoplayerView extends FrameLayout implements
     protected boolean playInBackground = false;
     private boolean mReportBandwidth = false;
     private boolean controls = false;
+    private int pictureInPictureResizeMode = -1;
 
     private boolean showNotificationControls = false;
     // \ End props
@@ -2508,6 +2509,16 @@ public class ReactExoplayerView extends FrameLayout implements
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && currentActivity.isInPictureInPictureMode()) {
             currentActivity.moveTaskToBack(false);
+        }
+    }
+
+    public void setPictureInPictureResizeModeModifier(@ResizeMode.Mode int resizeMode) {
+        this.pictureInPictureResizeMode = resizeMode;
+    }
+
+    public void setPictureInPictureMode(boolean isInPiP) {
+        if (exoPlayerView != null && isInPiP && pictureInPictureResizeMode != -1) {
+            exoPlayerView.setResizeMode(pictureInPictureResizeMode);
         }
     }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
@@ -58,6 +58,7 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         private const val PROP_SHOW_NOTIFICATION_CONTROLS = "showNotificationControls"
         private const val PROP_DEBUG = "debug"
         private const val PROP_CONTROLS_STYLES = "controlsStyles"
+        private const val PROP_PICTURE_IN_PICTURE_RESIZE_MODE = "pictureInPictureResizeMode"
     }
 
     override fun getName(): String = REACT_CLASS
@@ -258,9 +259,21 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         videoView.setDebug(enableDebug)
     }
 
-    @ReactProp(name = PROP_CONTROLS_STYLES)
-    fun setControlsStyles(videoView: ReactExoplayerView, controlsStyles: ReadableMap?) {
-        val controlsConfig = ControlsConfig.parse(controlsStyles)
-        videoView.setControlsStyles(controlsConfig)
+    @ReactProp(name = PROP_PICTURE_IN_PICTURE_RESIZE_MODE)
+    fun setPictureInPictureResizeMode(videoView: ReactExoplayerView, resizeMode: String?) {
+        val mode = when (resizeMode) {
+            "none", "contain" -> ResizeMode.RESIZE_MODE_FIT
+            "cover" -> ResizeMode.RESIZE_MODE_CENTER_CROP
+            "stretch" -> ResizeMode.RESIZE_MODE_FILL
+            else -> {
+                if (resizeMode != null) {
+                    DebugLog.w(TAG, "Unsupported PiP resize mode: $resizeMode - falling back to fit")
+                }
+                ResizeMode.RESIZE_MODE_FIT
+            }
+        }
+
+        videoView.setPictureInPictureResizeModeModifier(mode)
     }
+
 }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
@@ -276,4 +276,10 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         videoView.setPictureInPictureResizeModeModifier(mode)
     }
 
+    @ReactProp(name = PROP_CONTROLS_STYLES)
+    fun setControlsStyles(videoView: ReactExoplayerView, controlsStyles: ReadableMap?) {
+        val controlsConfig = ControlsConfig.parse(controlsStyles)
+        videoView.setControlsStyles(controlsConfig)
+    }
+
 }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.kt
@@ -281,5 +281,4 @@ class ReactExoplayerViewManager(private val config: ReactExoplayerConfig) : View
         val controlsConfig = ControlsConfig.parse(controlsStyles)
         videoView.setControlsStyles(controlsConfig)
     }
-
 }

--- a/examples/expo/android/app/src/main/java/com/anonymous/ExpoExample/MainActivity.kt
+++ b/examples/expo/android/app/src/main/java/com/anonymous/ExpoExample/MainActivity.kt
@@ -41,7 +41,7 @@ class MainActivity : ReactActivity() {
               this,
               mainComponentName,
               fabricEnabled
-          ){})
+          ) {})
   }
 
   /**

--- a/examples/expo/android/app/src/main/java/com/anonymous/ExpoExample/MainApplication.kt
+++ b/examples/expo/android/app/src/main/java/com/anonymous/ExpoExample/MainApplication.kt
@@ -25,7 +25,7 @@ class MainApplication : Application(), ReactApplication {
           override fun getPackages(): List<ReactPackage> {
             // Packages that cannot be autolinked yet can be added manually here, for example:
             var packages = PackageList(this).packages
-            packages.add(ReactVideoPackage());
+            packages.add(ReactVideoPackage())
             return packages
           }
 

--- a/examples/expo/android/react-settings-plugin/build.gradle.kts
+++ b/examples/expo/android/react-settings-plugin/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 
 plugins {
     kotlin("jvm") version "1.9.24"

--- a/examples/react-native-video-plugin-sample/android/src/main/java/com/videopluginsample/VideoPluginSampleModule.kt
+++ b/examples/react-native-video-plugin-sample/android/src/main/java/com/videopluginsample/VideoPluginSampleModule.kt
@@ -34,7 +34,6 @@ class VideoPluginSampleModule(reactContext: ReactApplicationContext) :
     DebugLog.e(TAG, "onPlayerError: " + error.errorCodeName)
   }
 
-
   override fun onInstanceCreated(id: String, player: ExoPlayer) {
     player.addAnalyticsListener(debugEventLogger)
     player.addListener(this)

--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ],
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "eslint-plugin-react-native": "^5.0.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
+        "ktlint": "^0.0.5",
         "prettier": "^3.6.2",
         "react": "18.2.0",
         "react-native": "0.78.2",
@@ -76,5 +77,6 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ]
+    ],
+    "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
 }

--- a/package.json
+++ b/package.json
@@ -76,5 +76,5 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ],
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
         "@react-native/eslint-config": "^0.72.2",
         "@release-it/conventional-changelog": "^7.0.2",
         "@types/jest": "^28.1.2",
-        "@types/node": "^24.3.0",
         "@types/react": "~19.0.0",
         "@types/react-native-web": "^0.19.1",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
@@ -69,5 +68,4 @@
         "!docs",
         "!examples"
     ],
-    "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
 }

--- a/package.json
+++ b/package.json
@@ -77,5 +77,4 @@
         "!docs",
         "!examples"
     ],
-    "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "@react-native/eslint-config": "^0.72.2",
         "@release-it/conventional-changelog": "^7.0.2",
         "@types/jest": "^28.1.2",
+        "@types/node": "^24.3.0",
         "@types/react": "~19.0.0",
         "@types/react-native-web": "^0.19.1",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
@@ -67,5 +68,6 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ]
+    ],
+    "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
 }

--- a/package.json
+++ b/package.json
@@ -15,17 +15,26 @@
     "devDependencies": {
         "@expo/config-plugins": "^8.0.5",
         "@jamesacarr/eslint-formatter-github-actions": "^0.2.0",
-        "@react-native/eslint-config": "^0.72.2",
+        "@react-native/eslint-config": "0.81.1",
+        "@react-native/eslint-plugin": "0.81.1",
         "@release-it/conventional-changelog": "^7.0.2",
         "@types/jest": "^28.1.2",
         "@types/react": "~19.0.0",
         "@types/react-native-web": "^0.19.1",
-        "@typescript-eslint/eslint-plugin": "^6.7.4",
-        "eslint": "^8.19.0",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "eslint": "^8",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-ft-flow": "^3.0.11",
         "eslint-plugin-jest": "^27.4.2",
+        "eslint-plugin-prettier": "^5.5.4",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-native": "^5.0.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
-        "prettier": "^2.4.1",
+        "prettier": "^3.6.2",
         "react": "18.2.0",
         "react-native": "0.78.2",
         "react-native-web": "0.20.0",
@@ -67,5 +76,6 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ]
+    ],
+    "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
 }

--- a/package.json
+++ b/package.json
@@ -77,5 +77,6 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ]
+    ],
+    "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,5 @@
         "!**/*.tsbuildinfo",
         "!docs",
         "!examples"
-    ],
-    "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
+    ]
 }

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -109,6 +109,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       localSourceEncryptionKeyScheme,
       minLoadRetryCount,
       bufferConfig,
+      pictureInPictureResizeMode,
       ...rest
     },
     ref,
@@ -905,6 +906,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
             onControlsVisibilityChange ? _onControlsVisibilityChange : undefined
           }
           viewType={_viewType}
+          pictureInPictureResizeMode={pictureInPictureResizeMode}
         />
         {_renderPoster()}
       </View>

--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -401,6 +401,7 @@ export interface VideoNativeProps extends ViewProps {
   onTextTracks?: DirectEventHandler<OnTextTracksData>; // android
   onTextTrackDataChanged?: DirectEventHandler<OnTextTrackDataChangedData>; // iOS
   onVideoTracks?: DirectEventHandler<OnVideoTracksData>; // android
+  pictureInPictureResizeMode?: WithDefault<string, 'none'>;
 }
 
 type NativeVideoComponentType = HostComponent<VideoNativeProps>;

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -91,14 +91,14 @@ export type Drm = Readonly<{
   base64Certificate?: boolean; // ios default: false
   multiDrm?: boolean; // android
   localSourceEncryptionKeyScheme?: string; // ios
-  /* eslint-disable @typescript-eslint/no-unused-vars */
+
   getLicense?: (
     spcBase64: string,
     contentId: string,
     licenseUrl: string,
     loadedLicenseUrl: string,
   ) => string | Promise<string>; // ios
-  /* eslint-enable @typescript-eslint/no-unused-vars */
+
 }>;
 
 export enum CmcdMode {

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -351,4 +351,5 @@ export interface ReactVideoProps extends ReactVideoEvents, ViewProps {
   allowsExternalPlayback?: boolean; // iOS
   controlsStyles?: ControlsStyles; // Android
   disableAudioSessionManagement?: boolean; // iOS
+  pictureInPictureResizeMode?: EnumValues<VideoResizeMode>; // Android
 }


### PR DESCRIPTION
## Summary
Fix for [BUG]: Video rect not updating #4488 on Android.

### Motivation
On Android, the Picture-in-Picture (PIP) feature did not correctly resize the video when exiting PIP mode and returning to the app. The video retained the PIP dimensions instead of adapting to the normal screen size.

### Changes
Modified ReactExoplayerView.java.
In setIsInPictureInPicture, added a post(requestLayout()) to force the layout recalculation after exiting PIP.
Result: video now correctly resizes to fit the screen after leaving PIP.

## Test plan
- Open a video on Android.
- Enter Picture-in-Picture mode (background the app).
- Return to the app.
- Verify that the video resizes correctly to fit the screen.
- Without this change, the video retains the PIP dimensions.
![fix](https://github.com/user-attachments/assets/975dbe9d-6723-42f3-aec5-43eac52a3881)
![unfix](https://github.com/user-attachments/assets/eab5d23e-17f5-4fda-8a53-6ca6a403a331)
