### PR TITLE
chore: update release script

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,9 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "typecheck": "tsc",
-    "start": "react-native start --client-logs"
+    "start": "react-native start --client-logs",
+    "bundle-install": "bundle install",
+    "pods": "cd ios && pod install && cd .."
   },
   "dependencies": {
     "@react-native-community/slider": "^4.5.6",

--- a/package.json
+++ b/package.json
@@ -64,13 +64,18 @@
       "release": true
     },
     "hooks": {
-      "before:release": "bun run --cwd packages/react-native-video build"
+      "before:release": "bun run --cwd packages/react-native-video build && bun run --cwd packages/drm-plugin build",
+      "before:git": "bun install && bun example bundle-install && bun example pods && git add bun.lock && git add example/ios/Podfile.lock"
     },
     "plugins": {
       "@release-it/bumper": {
         "out": [
           {
             "file": "packages/react-native-video/package.json",
+            "path": "version"
+          },
+          {
+            "file": "packages/drm-plugin/package.json",
             "path": "version"
           },
           {
@@ -90,6 +95,10 @@
             {
               "type": "fix",
               "section": "Bug Fixes 🐛"
+            },
+            {
+              "type": "refactor",
+              "section": "Code Refactoring 🛠"
             },
             {
               "type": "chore(deps)",

--- a/packages/drm-plugin/package.json
+++ b/packages/drm-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twg/react-native-video-drm",
-  "version": "0.1.0",
+  "version": "7.0.0-alpha.5",
   "description": "DRM plugin for react-native-video",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",
@@ -41,7 +41,7 @@
     "prepare": "bun run build",
     "build": "bob build",
     "specs": "nitrogen",
-    "release": "release-it --only-version"
+    "release": "release-it --preRelease alpha --npm.tag=next"
   },
   "keywords": [
     "react-native",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,14 +18,9 @@ cd ../..
 
 echo "[DRM Plugin] Publishing drm plugin"
 
-read -p "[DRM Plugin] Do you want to release the DRM plugin? (y/n): " confirm
-if [[ $confirm == "y" || $confirm == "Y" ]]; then
-  cd packages/drm-plugin
-  bun run release $@
-  cd ../..
-else
-  echo "[DRM Plugin] Skipping DRM plugin release."
-fi
+cd packages/drm-plugin
+bun run release $@
+cd ../..
 
 echo "[React Native Video] Making Github Release"
 bun run release:github $@


### PR DESCRIPTION
## Summary
Updated release script to release both packages
- From now `@twg/react-native-video-drm` will be versioned same as `react-native-video`
- From now release commit will also include updated `bun.lock` and example `Podfile.lock`