### PR TITLE
fix(ios): Configure audio session before activation and only if playing

### DIFF
--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -72,10 +72,9 @@ class AudioSessionManager {
         }
 
         if isAnyPlayerPlaying || remoteControlEventsActive {
+            configureAudioSession()
             activateAudioSession()
         }
-
-        configureAudioSession()
     }
 
     // Handle remote control events from NowPlayingInfoCenterManager


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

There's an issue on iOS that even if the player is configured to mix audio with others and even if the player is muted, when the player is mounted it steals audio focus from possible background audio. 

### Motivation

Fixes #4610

We've been running this change as a patch in our production app for a couple of months with no issues and it fixed the linked issue.

### Changes

Configuring the audio session only if there's an existing player and configuring the audio session before activating it.

The idea in the fix is that we do not even try to configure the audio session if there there are no players playing, since it's not possible to configure it correctly unless there are some existing players where we would get the configuration values from, so it ends up defaulting in possibly incorrect audio category/mode in that case. Also do the configuration before activating the audio session since that's what Apple recommends:
"Typically, you set the category and mode before activating the session. You can also set the category or mode while the session is active, but doing so results in an immediate change." from: https://developer.apple.com/documentation/avfaudio/avaudiosession/setcategory(_:mode:options:)

## Test plan

- Start a background audio in another app (e.g. a music player)
- Start the app with the react-native-video player that is configured to mix audio with others or is muted
- The background audio should no longer stop playing when the app is started
