### PR TITLE
feat(ios): add PublicAudioSessionManager for audio session management…

### DIFF
--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -7,6 +7,7 @@ class AudioSessionManager {
     private var videoViews = NSHashTable<RCTVideo>.weakObjects()
     private var isAudioSessionActive = false
     private var remoteControlEventsActive = false
+    private var isAudioSessionManagementForcedDisabled = false
 
     private var isAudioSessionManagementDisabled: Bool {
         // If no views are registered, disable audio session management
@@ -42,6 +43,10 @@ class AudioSessionManager {
     }
 
     // MARK: - Public API
+
+    func setIsAudioSessionManagementForcedDisabled(disabled:Bool) {
+        isAudioSessionManagementForcedDisabled = disabled
+    }
 
     func registerView(view: RCTVideo) {
         if videoViews.contains(view) {

--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -44,7 +44,7 @@ class AudioSessionManager {
 
     // MARK: - Public API
 
-    func setIsAudioSessionManagementForcedDisabled(disabled:Bool) {
+    func setIsAudioSessionManagementForcedDisabled(disabled: Bool) {
         isAudioSessionManagementForcedDisabled = disabled
     }
 

--- a/ios/Video/AudioSessionManager.swift
+++ b/ios/Video/AudioSessionManager.swift
@@ -10,6 +10,9 @@ class AudioSessionManager {
     private var isAudioSessionManagementForcedDisabled = false
 
     private var isAudioSessionManagementDisabled: Bool {
+        if isAudioSessionManagementForcedDisabled {
+            return true
+        }
         // If no views are registered, disable audio session management
         if videoViews.allObjects.isEmpty {
             return true

--- a/ios/Video/PublicAudioSessionManager.swift
+++ b/ios/Video/PublicAudioSessionManager.swift
@@ -6,4 +6,3 @@ public class PublicAudioSessionManager: NSObject {
 		AudioSessionManager.shared.setIsAudioSessionManagementForcedDisabled(disabled: disabled)
 	}
 }
-

--- a/ios/Video/PublicAudioSessionManager.swift
+++ b/ios/Video/PublicAudioSessionManager.swift
@@ -2,7 +2,8 @@ import Foundation
 
 @objc
 public class PublicAudioSessionManager: NSObject {
-	@objc public static func setIsAudioSessionManagementDisabled(_ disabled: Bool) {
-		AudioSessionManager.shared.setIsAudioSessionManagementForcedDisabled(disabled: disabled)
-	}
+    @objc
+    public static func setIsAudioSessionManagementDisabled(_ disabled: Bool) {
+        AudioSessionManager.shared.setIsAudioSessionManagementForcedDisabled(disabled: disabled)
+    }
 }

--- a/ios/Video/PublicAudioSessionManager.swift
+++ b/ios/Video/PublicAudioSessionManager.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@objc
+public class PublicAudioSessionManager: NSObject {
+	@objc public static func setIsAudioSessionManagementDisabled(_ disabled: Bool) {
+		AudioSessionManager.shared.setIsAudioSessionManagementForcedDisabled(disabled: disabled)
+	}
+}
+


### PR DESCRIPTION
Added a public PublicAudioSessionManager class on iOS to allow enabling or disabling the audio session manager directly from the native side.
This makes it possible for other native modules or app code to manage the audio session state without relying solely on JS integration.
**Useful for call apps**