### PR TITLE
Fix: use top-most presented view controller for fullscreen presentation on iOS

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1090,15 +1090,9 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             _playerViewController?.modalPresentationStyle = .fullScreen
 
             // Find the nearest view controller
-            var viewController: UIViewController! = self.firstAvailableUIViewController()
-            if viewController == nil {
-                guard let keyWindow = RCTVideoUtils.getCurrentWindow() else { return }
-
-                viewController = keyWindow.rootViewController
-                if !viewController.children.isEmpty {
-                    viewController = viewController.children.last
-                }
-            }
+            var viewController: UIViewController! = RCTPresentedViewController() ?? RCTKeyWindow()?.rootViewController
+            guard viewController != nil else { return }
+            while let presented = viewController.presentedViewController { viewController = presented }
             if viewController != nil {
                 _presentingViewController = viewController
 


### PR DESCRIPTION
This PR fixes a layout issue on iOS when using .fullScreen presentation style.

Previously, RCTVideo would use firstAvailableUIViewController() or the root controller’s last child to present the fullscreen player.
However, this could result in incorrect layout updates when exiting fullscreen — especially in apps using react-navigation, tab scenes.

By switching to RCTPresentedViewController() and walking up the presentedViewController chain, we ensure that the fullscreen player is always presented from the top-most visible view controller.
This resolves issues where exiting fullscreen would cause the underlying content to shift upward.



before:

https://github.com/user-attachments/assets/61e176f5-ea21-465d-9584-49920fbac1c0




after:

https://github.com/user-attachments/assets/6a918fc1-6fe1-401b-a635-656167253e0d


