### PR TITLE
feat(android): Add expo config for notification controls

### DIFF
--- a/packages/react-native-video/src/expo-plugins/withAndroidNotificationControls.ts
+++ b/packages/react-native-video/src/expo-plugins/withAndroidNotificationControls.ts
@@ -1,0 +1,43 @@
+import {
+  AndroidConfig,
+  type ConfigPlugin,
+  withAndroidManifest,
+} from '@expo/config-plugins';
+
+export const withAndroidNotificationControls: ConfigPlugin = (oldConfig) => {
+  return withAndroidManifest(oldConfig, (config) => {
+    const mainApplication = AndroidConfig.Manifest.getMainApplication(
+      config.modResults
+    );
+    if (!mainApplication) {
+      console.warn(
+        'AndroidManifest.xml is missing an <activity android:name=".MainActivity" /> element - skipping adding Notification Controls related config.'
+      );
+      return config;
+    }
+    mainApplication.service?.push({
+      $: {
+        'android:name':
+          'com.twg.video.core.services.playback.VideoPlaybackService',
+        'android:exported': 'false',
+        'android:foregroundServiceType': 'mediaPlayback',
+      },
+      'intent-filter': [
+        {
+          action: [
+            {
+              $: {
+                'android:name': 'androidx.media3.session.MediaSessionService',
+              },
+            },
+          ],
+        },
+      ],
+    });
+    config.android?.permissions?.push(
+      'android.permission.FOREGROUND_SERVICE',
+      'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK'
+    );
+    return config;
+  });
+};

--- a/packages/react-native-video/src/expo-plugins/withReactNativeVideo.ts
+++ b/packages/react-native-video/src/expo-plugins/withReactNativeVideo.ts
@@ -4,6 +4,7 @@ import { getPackageInfo } from './getPackageInfo';
 import { withAndroidExtensions } from './withAndroidExtensions';
 import { withAndroidPictureInPicture } from './withAndroidPictureInPicture';
 import { withBackgroundAudio } from './withBackgroundAudio';
+import { withAndroidNotificationControls } from './withAndroidNotificationControls';
 
 const withRNVideo: ConfigPlugin<ConfigProps> = (config, props = {}) => {
   if (props.enableAndroidPictureInPicture) {
@@ -20,6 +21,8 @@ const withRNVideo: ConfigPlugin<ConfigProps> = (config, props = {}) => {
   if (props.enableBackgroundAudio) {
     config = withBackgroundAudio(config, props.enableBackgroundAudio);
   }
+
+  config = withAndroidNotificationControls(config);
 
   return config;
 };


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

Adding Expo configuration for notification controls on Android

Sources:
- v6 doc: [Link](https://docs.thewidlarzgroup.com/react-native-video/docs/v6/component/props#shownotificationcontrols)

### Notes

- First contribution, lmk if the contributed code doesn't comply to norm/coding style
- The plugin is invoked unconditionally because there is not toggle setting for notifications controls, unlike in v6. It might be relevant to add a boolean in the settings to enable/disable the plugin. I can add do that in this PR if need be.

### Motivation

Including this will avoid the user to write the configuration themselves.
(It can be a pain for unexperiences users)

### Changes

- Add Expo config for notification controls 
- Call config function in main plugin

## Test plan

- [ ] Test using `example` app
   - Can't manage to build/run it locally, but I added that same config in my project ([link](https://github.com/Arthi-chaud/Meelo/blob/main/front/apps/mobile/plugins/withMediaServicePlugin.ts)) and it works.
