### PR TITLE
fix(ios): don't recreate AVPlayerViewController if player haven't changed

### DIFF
--- a/packages/react-native-video/ios/view/VideoComponentView.swift
+++ b/packages/react-native-video/ios/view/VideoComponentView.swift
@@ -76,7 +76,7 @@ import UIKit
 
         VideoManager.shared.requestAudioSessionUpdate()
         playerViewController.canStartPictureInPictureAutomaticallyFromInline =
-          self.allowsPictureInPicturePlayback
+          self.autoEnterPictureInPicture
       }
     }
   }


### PR DESCRIPTION
## Summary
Previously we have re-created `AVPlayerViewController` each time `player` was set (even for same player on re-render). This PR fixes it and skips it when player have not changed