### PR TITLE
fix(android): prevent duplicate onVideoEnd callback on prop changes

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -227,6 +227,7 @@ public class ReactExoplayerView extends FrameLayout implements
      */
     private boolean isSeeking = false;
     private long seekPosition = -1;
+    private boolean hasVideoEnded = false;
 
     // Props from React
     private Source source = new Source();
@@ -1411,6 +1412,7 @@ public class ReactExoplayerView extends FrameLayout implements
                     break;
                 case Player.STATE_READY:
                     text += "ready";
+                    hasVideoEnded = false;
                     eventEmitter.onReadyForDisplay.invoke();
                     onBuffering(false);
                     clearProgressMessageHandler(); // ensure there is no other message
@@ -1429,7 +1431,10 @@ public class ReactExoplayerView extends FrameLayout implements
                 case Player.STATE_ENDED:
                     text += "ended";
                     updateProgress();
-                    eventEmitter.onVideoEnd.invoke();
+                    if (!hasVideoEnded) {
+                        hasVideoEnded = true;
+                        eventEmitter.onVideoEnd.invoke();
+                    }
                     onStopPlayback();
                     setKeepScreenOn(false);
                     break;
@@ -1819,7 +1824,10 @@ public class ReactExoplayerView extends FrameLayout implements
         if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION
                 && player.getRepeatMode() == Player.REPEAT_MODE_ONE) {
             updateProgress();
-            eventEmitter.onVideoEnd.invoke();
+            if (!hasVideoEnded) {
+                hasVideoEnded = true;
+                eventEmitter.onVideoEnd.invoke();
+            }
         }
     }
 
@@ -2030,6 +2038,7 @@ public class ReactExoplayerView extends FrameLayout implements
             }
 
             if (!isSourceEqual) {
+                hasVideoEnded = false;
                 playerNeedsSource = true;
                 initializePlayer();
             }


### PR DESCRIPTION

<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary

Fixes: #4761 

- Add hasVideoEnded flag to prevent onVideoEnd from being invoked multiple times when props change after video completion.
- ExoPlayer fires both STATE_ENDED and DISCONTINUITY_REASON_AUTO_TRANSITION events when video ends, causing duplicate callbacks especially when props like 'paused' change in the onEnd handler.


### Motivation
On Android ExoPlayer, `onEnd` is called twice when props (like `paused`) change in the callback handler. iOS and MediaPlayer work correctly with a single call.

**Issue:**

- Video ends → onEnd called Props change → onEnd called AGAIN ✗


This causes duplicate analytics, double state updates, and platform inconsistency.

### Root Cause

ExoPlayer fires both `STATE_ENDED` and `DISCONTINUITY_REASON_AUTO_TRANSITION` events simultaneously, each triggering `onVideoEnd.invoke()`.

### Changes

Added `hasVideoEnded` flag to prevent duplicate calls:
- Check flag before invoking `onVideoEnd` in both event handlers
- Reset flag when video is ready, new source loaded, or source cleared

Similar pattern to existing `isSeeking` flag.

## Test plan
