### PR TITLE
fix: prevent audiovisualBackgroundPlaybackPolicy crash

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -573,14 +573,15 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             ReactNativeVideoManager.shared.onInstanceCreated(id: instanceId, player: _player as Any)
 
             _player!.replaceCurrentItem(with: playerItem)
-
-            if #available(iOS 15.0, *) {
-                if _playInBackground {
-                    _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
-                } else {
-                    _player!.audiovisualBackgroundPlaybackPolicy = .automatic
+            #if !os(tvOS) && !os(visionOS)
+                if #available(iOS 15.0, *) {
+                    if _playInBackground {
+                        _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
+                    } else {
+                        _player!.audiovisualBackgroundPlaybackPolicy = .automatic
+                    }
                 }
-            }
+            #endif
 
             if _showNotificationControls {
                 // We need to register player after we set current item and only for init
@@ -601,13 +602,15 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 }
             #endif
 
-            if #available(iOS 15.0, *) {
-                if _playInBackground {
-                    _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
-                } else {
-                    _player!.audiovisualBackgroundPlaybackPolicy = .automatic
+            #if !os(tvOS) && !os(visionOS)
+                if #available(iOS 15.0, *) {
+                    if _playInBackground {
+                        _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
+                    } else {
+                        _player!.audiovisualBackgroundPlaybackPolicy = .automatic
+                    }
                 }
-            }
+            #endif
             // later we can just call "updateNowPlayingInfo:
             NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
         }


### PR DESCRIPTION
This prevents an error when building your app for tvOS. I assume this also happens when building for visionOS.

It fixes the following error message: ` audiovisualBackgroundPlaybackPolicy is only available in tvOS 15.0 or newer.`

<img width="852" height="293" alt="Screenshot 2025-11-05 at 12 36 17" src="https://github.com/user-attachments/assets/19fc86cf-0879-4692-a074-55f4fcdb108f" />

