### PR TITLE
fix(ios): IMA ad container resizing on orientation change

### DIFF
--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -35,7 +35,7 @@
             adContainerView.backgroundColor = .clear
             _video.addSubview(adContainerView)
 
-            // added layout resize according to subview of video
+            // Enable Auto Layout to ensure the ad container resizes with the video view.
             adContainerView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 adContainerView.topAnchor.constraint(equalTo: _video.topAnchor),

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -34,14 +34,14 @@
             let adContainerView = UIView(frame: _video.bounds)
             adContainerView.backgroundColor = .clear
             _video.addSubview(adContainerView)
-            
+
             // added layout resize according to subview of video
             adContainerView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 adContainerView.topAnchor.constraint(equalTo: _video.topAnchor),
                 adContainerView.bottomAnchor.constraint(equalTo: _video.bottomAnchor),
                 adContainerView.leadingAnchor.constraint(equalTo: _video.leadingAnchor),
-                adContainerView.trailingAnchor.constraint(equalTo: _video.trailingAnchor)
+                adContainerView.trailingAnchor.constraint(equalTo: _video.trailingAnchor),
             ])
 
             // Create ad display container for ad rendering.

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -34,6 +34,15 @@
             let adContainerView = UIView(frame: _video.bounds)
             adContainerView.backgroundColor = .clear
             _video.addSubview(adContainerView)
+            
+            // added layout resize according to subview of video
+            adContainerView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                adContainerView.topAnchor.constraint(equalTo: _video.topAnchor),
+                adContainerView.bottomAnchor.constraint(equalTo: _video.bottomAnchor),
+                adContainerView.leadingAnchor.constraint(equalTo: _video.leadingAnchor),
+                adContainerView.trailingAnchor.constraint(equalTo: _video.trailingAnchor)
+            ])
 
             // Create ad display container for ad rendering.
             let adDisplayContainer = IMAAdDisplayContainer(adContainer: adContainerView, viewController: _video.reactViewController())

--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -31,7 +31,7 @@
         func requestAds() {
             guard let _video else { return }
             // fixes RCTVideo --> RCTIMAAdsManager --> IMAAdsLoader --> IMAAdDisplayContainer --> RCTVideo memory leak.
-            let adContainerView = UIView(frame: _video.bounds)
+            let adContainerView = UIView()
             adContainerView.backgroundColor = .clear
             _video.addSubview(adContainerView)
 


### PR DESCRIPTION
Fixes an issue where the IMA ad container view did not resize correctly when device orientation changed on iOS.
Previously, adContainerView was initialised with a static frame (_video.bounds), so it didn’t update after rotation.

🛠️ Changes

Replaced frame-based layout with Auto Layout constraints to pin adContainerView to _video on all edges.
Ensures proper resizing on orientation change while retaining the existing memory leak fix.
Tested on iOS 15.1+ (iPhone simulators) — ads now stay correctly aligned after rotation.
✅ Verification

Verified that ads render correctly in both portrait and landscape modes.
Confirmed no new memory leaks or constraint warnings.
Maintains backward compatibility with existing React Native Video integrations.