### PR TITLE
fix: entering PiP mode when controls are true

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -172,14 +172,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         #endif
     }
 
-    func setupPictureInPicture() {
-        #if os(iOS)
-            if _playerLayer != nil && !_controls && _pip?._pipController == nil {
-                _pip?.setupPipController(_playerLayer)
-            }
-        #endif
-    }
-
     func initPictureinPicture() {
         #if os(iOS)
             if _pip == nil {
@@ -1859,16 +1851,9 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 initPictureinPicture()
             }
             
-            if _pip?._pipController == nil, let playerViewController = _playerViewController, _controls, let player = _player {
-                if #available(iOS 9.0, *) {
-                    if let existingPlayerLayer = findPlayerLayer(in: playerViewController.view) {
-                        _pip?.setupPipController(existingPlayerLayer)
-                    } else {
-                        let pipLayer = AVPlayerLayer(player: player)
-                        pipLayer.frame = playerViewController.view.bounds
-                        pipLayer.videoGravity = playerViewController.videoGravity
-                        _pip?.setupPipController(pipLayer)
-                    }
+            if _pip?._pipController == nil, let playerViewController = _playerViewController, _controls {
+                if let existingPlayerLayer = findPlayerLayer(in: playerViewController.view) {
+                    _pip?.setupPipController(existingPlayerLayer)
                 }
             }
             
@@ -1892,3 +1877,4 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func setOnClick(_: Any) {}
 }
+

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -68,14 +68,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             if isPictureInPictureActive() { return }
             if _enterPictureInPictureOnLeave {
                 initPictureinPicture()
-                if #available(iOS 9.0, tvOS 14.0, *) {
-                    _playerViewController?.allowsPictureInPicturePlayback = true
-                }
             } else {
                 _pip?.deinitPipController()
-                if #available(iOS 9.0, tvOS 14.0, *) {
-                    _playerViewController?.allowsPictureInPicturePlayback = false
-                }
             }
         }
     }
@@ -1222,9 +1216,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             }
         }
 
-        if #available(iOS 9.0, tvOS 14.0, *) {
-            viewController.allowsPictureInPicturePlayback = _enterPictureInPictureOnLeave
-        }
         return viewController
     }
 
@@ -1853,7 +1844,6 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             
             if _pip?._pipController == nil, let playerViewController = _playerViewController, _controls, let player = _player {
                 if #available(iOS 9.0, *) {
-                    playerViewController.allowsPictureInPicturePlayback = false
                     let pipLayer = AVPlayerLayer(player: player)
                     pipLayer.frame = playerViewController.view.bounds
                     pipLayer.videoGravity = playerViewController.videoGravity
@@ -1872,14 +1862,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         _pip?.exitPictureInPicture()
         if _enterPictureInPictureOnLeave {
             initPictureinPicture()
-            if #available(iOS 9.0, tvOS 14.0, *) {
-                _playerViewController?.allowsPictureInPicturePlayback = true
-            }
         } else {
             _pip?.deinitPipController()
-            if #available(iOS 9.0, tvOS 14.0, *) {
-                _playerViewController?.allowsPictureInPicturePlayback = false
-            }
         }
     }
 

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1850,13 +1850,13 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             if _pip == nil {
                 initPictureinPicture()
             }
-            
+
             if _pip?._pipController == nil, let playerViewController = _playerViewController, _controls {
                 if let existingPlayerLayer = findPlayerLayer(in: playerViewController.view) {
                     _pip?.setupPipController(existingPlayerLayer)
                 }
             }
-            
+
             _pip?.enterPictureInPicture()
         #endif
     }
@@ -1877,4 +1877,3 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     @objc
     func setOnClick(_: Any) {}
 }
-


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
Fixed Picture in Picture (PiP) when controls are enabled. Previously, PiP worked without controls (using AVPlayerLayer) but failed with controls enabled (using AVPlayerViewController), causing PiP to exit shortly after entering
Unified PiP to always use AVPictureInPictureController with AVPlayerLayer:
- When controls are disabled: uses existing _playerLayer
- When controls are enabled: finds the existing AVPlayerLayer inside AVPlayerViewController's view hierarchy

We use a custom `_isPictureInPictureActive` to make sure it works every time. _pip?._pipController?.isPictureInPictureActive wasn't true when using controls
### Motivation
Fixes #4732
### Changes

## Test plan
Run app with:
```ts
      <Video
        ref={videoRef}
        source={{
          uri: "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
        }}
        playInBackground
        controls={true}
        showNotificationControls
        playWhenInactive
        allowsExternalPlayback
        enterPictureInPictureOnLeave
        style={{ width: "100%", aspectRatio: 16 / 9 }}
      />
```
verify if controls are correctly opened