### PR TITLE
fix(android): correct videoTrack type definitions

### DIFF
--- a/src/specs/VideoNativeComponent.ts
+++ b/src/specs/VideoNativeComponent.ts
@@ -197,7 +197,7 @@ export type OnBandwidthUpdateData = Readonly<{
   bitrate: Int32;
   width?: Float;
   height?: Float;
-  trackId?: Int32;
+  trackId?: string;
 }>;
 
 export type OnSeekData = Readonly<{
@@ -248,7 +248,7 @@ export type OnTextTrackDataChangedData = Readonly<{
 export type OnVideoTracksData = Readonly<{
   videoTracks: {
     index: Int32;
-    tracksId?: string;
+    trackId?: string;
     codecs?: string;
     width?: Float;
     height?: Float;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -54,7 +54,7 @@ export type OnLoadData = Readonly<{
   }[];
   videoTracks: {
     index: number;
-    tracksID?: string;
+    trackId?: string;
     codecs?: string;
     width?: number;
     height?: number;


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->

## Description

This PR fixes type mismatches between the Android native implementation and TypeScript type definitions related to video track IDs.

## Changes

### 1. Fixed `onVideoTracks` callback type
- **Before**: `videoTracks.tracksId?: string`

<img width="363" height="171" alt="image" src="https://github.com/user-attachments/assets/0a16873f-cde8-4910-960d-9be80f4355f9" />

- **After**: `videoTracks.trackId?: string`


### 2. Fixed `onLoad` callback's `videoTracks` type
- **Before**: `videoTracks.tracksID?: string`

<img width="524" height="119" alt="image" src="https://github.com/user-attachments/assets/d415c03d-5823-4f01-a218-1d6e0989a113" />

- **After**: `videoTracks.trackId?: string`

### 3. Fixed `onBandwidthUpdate` callback type
- **Before**: `trackId?: Int32` (number)

<img width="363" height="171" alt="image" src="https://github.com/user-attachments/assets/396a8e78-2fb8-44ad-b637-70faabbab585" />

- **After**: `trackId?: string`


## Root Cause

The Android native code in [VideoTrack.kt](cci:7://file:///Users/saseungmin/workspace/sa-react-native-video/android/src/main/java/com/brentvatne/common/api/VideoTrack.kt:0:0-0:0) defines:
```kotlin
class VideoTrack {
    var trackId = ""  // String type
    // ...
}
```

However, the TypeScript definitions had:
- Incorrect property names (`tracksId`, `tracksID` instead of `trackId`)
- Incorrect type for bandwidth update (`Int32`(`number`) instead of `string`)

This caused type errors when accessing the `trackId` property in TypeScript code, as the actual runtime values from Android use `trackId` as a string.


## Testing

```tsx
<Video
    reportBandwidth
    onVideoTracks={(e) => console.log("Video tracks:", e.videoTracks[0].trackId)}
    onBandwidthUpdate={(e) =>
      console.log("Bandwidth update:", typeof e.trackId === "string")
    }
    onLoad={(e) => {
      console.log("Video load:", e.videoTracks[0].trackId);
    }}
/>
```

Verified that:
- Android native code consistently uses `trackId` as a string
- Console logging confirms the received values are strings
- Type definitions now match the actual runtime behavior

### Related Issue
Fixes #4756 
