### PR TITLE
fix: handles view not found error gracefully

### DIFF
--- a/packages/react-native-video/src/core/video-view/VideoView.tsx
+++ b/packages/react-native-video/src/core/video-view/VideoView.tsx
@@ -191,7 +191,7 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
               // the native manager may not have been able to find the view before the view was unmounted
               // This should really never happen, but it's better to be safe than sorry
 
-              // We don't throw an error here, because it's not a actual error.
+              // We don't throw an error here, because it's not an actual error.
               console.warn(
                 '[ReactNativeVideo] VideoView was unmounted before native manager was able to find it. It can happen when the view is quickly mounted and unmounted.'
               );

--- a/packages/react-native-video/src/core/video-view/VideoView.tsx
+++ b/packages/react-native-video/src/core/video-view/VideoView.tsx
@@ -185,7 +185,7 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
             // The view was not found, did view get unmounted?
             if (id === nitroId) {
               // The id from native is same as the one we have,
-              // so the view was unmounted before native manger was able to find it
+              // so the view was unmounted before native manager was able to find it
 
               // On slow devices, when we quickly mount and unmount the view,
               // the native manager may not have been able to find the view before the view was unmounted


### PR DESCRIPTION
## Summary
improves error handling in the `VideoView` component to better handle cases where the native video view is unmounted before the native manager can find it. Instead of throwing an error in this rare scenario, a warning is logged, preventing unnecessary exceptions and improving stability, especially on slower devices.