### PR TITLE
[ENG4BCMA-0000] Android. Always hide the live badge.

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.kt
@@ -214,8 +214,9 @@ class ExoPlayerView @JvmOverloads constructor(context: Context, attrs: Attribute
         val isLive = player.isCurrentMediaItemLive
         val seekable = player.isCurrentMediaItemSeekable
 
-        // Show/hide badge
-        liveBadge.visibility = if (isLive) View.VISIBLE else View.GONE
+        // Show/hide badge - always hide, see:
+        // https://github.com/TheWidlarzGroup/react-native-video/issues/4623#issuecomment-3218156762
+        liveBadge.visibility = View.GONE
 
         // Disable/enable scrubbing based on seekable
         val timeBar = playerView.findViewById<DefaultTimeBar?>(androidx.media3.ui.R.id.exo_progress)


### PR DESCRIPTION
## Summary
The Live Badge does not exists on iOS, but it does exist on Android.

Always hide the Live Badge on Android.

## TODO
Monitor
https://github.com/TheWidlarzGroup/react-native-video/issues/4623
to see when the possibility to control the presence of the Live Badge will be available in the `react-native-video` library.
