### PR TITLE
refactor: don't use nitro dispose

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
     },
     "example": {
       "name": "react-native-video-example",
-      "version": "7.0.0-beta.0",
+      "version": "7.0.0-beta.1",
       "dependencies": {
         "@react-native-community/slider": "^4.5.6",
         "@react-native-video/drm": "*",
@@ -79,7 +79,7 @@
     },
     "packages/drm-plugin": {
       "name": "@react-native-video/drm",
-      "version": "7.0.0-beta.0",
+      "version": "7.0.0-beta.1",
       "devDependencies": {
         "@react-native/babel-preset": "0.79.2",
         "@release-it/conventional-changelog": "^9.0.2",
@@ -107,7 +107,7 @@
     },
     "packages/react-native-video": {
       "name": "react-native-video",
-      "version": "7.0.0-beta.0",
+      "version": "7.0.0-beta.1",
       "devDependencies": {
         "@expo/config-plugins": "^10.0.2",
         "@react-native/eslint-config": "^0.77.0",

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1565,7 +1565,7 @@ PODS:
     - React-logger (= 0.77.3)
     - React-perflogger (= 0.77.3)
     - React-utils (= 0.77.3)
-  - ReactNativeVideo (7.0.0-beta.0):
+  - ReactNativeVideo (7.0.0-beta.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1587,7 +1587,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ReactNativeVideoDrm (7.0.0-beta.0):
+  - ReactNativeVideoDrm (7.0.0-beta.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1904,8 +1904,8 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 31015410a4a53b9fd0a908ad4d6e3e2b9a25086a
   ReactCodegen: 53316394e985ded1babc7f143c90c77d2bb1b43c
   ReactCommon: bf4612cba0fa356b529385029f470d5529dddde4
-  ReactNativeVideo: 5a5e609057e980e9ea2736914377804358c53ae9
-  ReactNativeVideoDrm: 4f266c3b018170319ed16bc511218c0d411358d5
+  ReactNativeVideo: 10dd0a47f8228b41565a3efb13df5b323633b590
+  ReactNativeVideoDrm: 07b826ab66fd0a00ab3dd3bef2dd2c026e919a9a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 92f3bb322c40a86b7233b815854730442e01b8c4
 

--- a/packages/drm-plugin/nitrogen/generated/android/c++/JHybridPluginManagerSpec.cpp
+++ b/packages/drm-plugin/nitrogen/generated/android/c++/JHybridPluginManagerSpec.cpp
@@ -33,6 +33,12 @@ namespace margelo::nitro::videodrm {
     method(_javaPart);
   }
 
+  std::string JHybridPluginManagerSpec::toString() {
+    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
+    auto javaString = method(_javaPart);
+    return javaString->toStdString();
+  }
+
   // Properties
   bool JHybridPluginManagerSpec::getIsEnabled() {
     static const auto method = javaClassStatic()->getMethod<jboolean()>("isEnabled");

--- a/packages/drm-plugin/nitrogen/generated/android/c++/JHybridPluginManagerSpec.hpp
+++ b/packages/drm-plugin/nitrogen/generated/android/c++/JHybridPluginManagerSpec.hpp
@@ -41,6 +41,7 @@ namespace margelo::nitro::videodrm {
   public:
     size_t getExternalMemorySize() noexcept override;
     void dispose() noexcept override;
+    std::string toString() override;
 
   public:
     inline const jni::global_ref<JHybridPluginManagerSpec::javaobject>& getJavaPart() const noexcept {

--- a/packages/drm-plugin/nitrogen/generated/android/kotlin/com/margelo/nitro/videodrm/HybridPluginManagerSpec.kt
+++ b/packages/drm-plugin/nitrogen/generated/android/kotlin/com/margelo/nitro/videodrm/HybridPluginManagerSpec.kt
@@ -10,7 +10,7 @@ package com.margelo.nitro.videodrm
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
-import com.margelo.nitro.core.*
+import com.margelo.nitro.core.HybridObject
 
 /**
  * A Kotlin class representing the PluginManager HybridObject.
@@ -34,6 +34,11 @@ abstract class HybridPluginManagerSpec: HybridObject() {
   override fun updateNative(hybridData: HybridData) {
     mHybridData = hybridData
     super.updateNative(hybridData)
+  }
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject PluginManager]"
   }
 
   // Properties

--- a/packages/drm-plugin/nitrogen/generated/ios/ReactNativeVideoDrm-Swift-Cxx-Bridge.cpp
+++ b/packages/drm-plugin/nitrogen/generated/ios/ReactNativeVideoDrm-Swift-Cxx-Bridge.cpp
@@ -10,6 +10,7 @@
 // Include C++ implementation defined types
 #include "HybridPluginManagerSpecSwift.hpp"
 #include "ReactNativeVideoDrm-Swift-Cxx-Umbrella.hpp"
+#include <NitroModules/NitroDefines.hpp>
 
 namespace margelo::nitro::videodrm::bridge::swift {
 

--- a/packages/drm-plugin/nitrogen/generated/ios/c++/HybridPluginManagerSpecSwift.hpp
+++ b/packages/drm-plugin/nitrogen/generated/ios/c++/HybridPluginManagerSpecSwift.hpp
@@ -50,6 +50,9 @@ namespace margelo::nitro::videodrm {
     void dispose() noexcept override {
       _swiftPart.dispose();
     }
+    std::string toString() override {
+      return _swiftPart.toString();
+    }
 
   public:
     // Properties

--- a/packages/drm-plugin/nitrogen/generated/ios/swift/HybridPluginManagerSpec.swift
+++ b/packages/drm-plugin/nitrogen/generated/ios/swift/HybridPluginManagerSpec.swift
@@ -18,6 +18,13 @@ public protocol HybridPluginManagerSpec_protocol: HybridObject {
   func disable() throws -> Void
 }
 
+public extension HybridPluginManagerSpec_protocol {
+  /// Default implementation of ``HybridObject.toString``
+  func toString() -> String {
+    return "[HybridObject PluginManager]"
+  }
+}
+
 /// See ``HybridPluginManagerSpec``
 open class HybridPluginManagerSpec_base {
   private weak var cxxWrapper: HybridPluginManagerSpec_cxx? = nil

--- a/packages/drm-plugin/nitrogen/generated/ios/swift/HybridPluginManagerSpec_cxx.swift
+++ b/packages/drm-plugin/nitrogen/generated/ios/swift/HybridPluginManagerSpec_cxx.swift
@@ -76,7 +76,7 @@ open class HybridPluginManagerSpec_cxx {
    */
   public func getCxxPart() -> bridge.std__shared_ptr_HybridPluginManagerSpec_ {
     let cachedCxxPart = self.__cxxPart.lock()
-    if cachedCxxPart.__convertToBool() {
+    if Bool(fromCxx: cachedCxxPart) {
       return cachedCxxPart
     } else {
       let newCxxPart = bridge.create_std__shared_ptr_HybridPluginManagerSpec_(self.toUnsafe())
@@ -103,6 +103,14 @@ open class HybridPluginManagerSpec_cxx {
   @inline(__always)
   public func dispose() {
     self.__implementation.dispose()
+  }
+
+  /**
+   * Call toString() on the Swift class.
+   */
+  @inline(__always)
+  public func toString() -> String {
+    return self.__implementation.toString()
   }
 
   // Properties

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
@@ -170,9 +170,17 @@ object VideoManager : LifecycleEventListener {
   }
 
   fun unregisterPlayer(player: HybridVideoPlayer) {
-    players.remove(player)
     audioFocusManager.unregisterPlayer(player)
     PluginsRegistry.shared.notifyPlayerDestroyed(WeakReference(player))
+
+    // Remove player from any views that were using it
+    players[player]?.forEach { nitroId ->
+      views[nitroId]?.get()?.let { view ->
+        view.hybridPlayer = null
+      }
+    }
+
+    players.remove(player)
   }
 
   fun getPlayerByNitroId(nitroId: Int): HybridVideoPlayer? {

--- a/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
@@ -391,8 +391,8 @@ class HybridVideoPlayer() : HybridVideoPlayerSpec(), AutoCloseable {
   }
 
   override val memorySize: Long
-    // 1MB by default
-    get() = allocator?.totalBytesAllocated?.toLong() ?: (1024L * 1000L)
+    // 1 MiB by default
+    get() = allocator?.totalBytesAllocated?.toLong() ?: (1024L * 1024L)
 
   private fun startProgressUpdates() {
     stopProgressUpdates() // Ensure no multiple runnables

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
@@ -49,7 +49,7 @@ extension HybridVideoPlayer: VideoPlayerObserverDelegate {
 
   func onPlaybackLikelyToKeepUp() {
     isCurrentlyBuffering = false
-    if player.timeControlStatus == .playing {
+    if player.timeControlStatus != .waitingToPlayAtSpecifiedRate {
       status = .readytoplay
     }
     updateAndEmitPlaybackState()

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -206,6 +206,9 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
   func release() {
     sourceLoader.cancelSync()
     NowPlayingInfoCenterManager.shared.removePlayer(player: player)
+    
+    try? _eventEmitter?.clearAllListeners()
+    
     self.player.replaceCurrentItem(with: nil)
     self.playerItem = nil
 

--- a/packages/react-native-video/nitrogen/generated/android/c++/JHybridVideoPlayerSpec.cpp
+++ b/packages/react-native-video/nitrogen/generated/android/c++/JHybridVideoPlayerSpec.cpp
@@ -228,6 +228,10 @@ namespace margelo::nitro::video {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JVariant_NullType_TextTrack> /* textTrack */)>("selectTextTrack");
     method(_javaPart, textTrack.has_value() ? JVariant_NullType_TextTrack::fromCpp(textTrack.value()) : nullptr);
   }
+  void JHybridVideoPlayerSpec::release() {
+    static const auto method = javaClassStatic()->getMethod<void()>("release");
+    method(_javaPart);
+  }
   std::shared_ptr<Promise<void>> JHybridVideoPlayerSpec::initialize() {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("initialize");
     auto __result = method(_javaPart);

--- a/packages/react-native-video/nitrogen/generated/android/c++/JHybridVideoPlayerSpec.hpp
+++ b/packages/react-native-video/nitrogen/generated/android/c++/JHybridVideoPlayerSpec.hpp
@@ -82,6 +82,7 @@ namespace margelo::nitro::video {
     std::shared_ptr<Promise<void>> replaceSourceAsync(const std::optional<std::variant<nitro::NullType, std::shared_ptr<HybridVideoPlayerSourceSpec>>>& source) override;
     std::vector<TextTrack> getAvailableTextTracks() override;
     void selectTextTrack(const std::optional<std::variant<nitro::NullType, TextTrack>>& textTrack) override;
+    void release() override;
     std::shared_ptr<Promise<void>> initialize() override;
     std::shared_ptr<Promise<void>> preload() override;
     void play() override;

--- a/packages/react-native-video/nitrogen/generated/android/kotlin/com/margelo/nitro/video/HybridVideoPlayerSpec.kt
+++ b/packages/react-native-video/nitrogen/generated/android/kotlin/com/margelo/nitro/video/HybridVideoPlayerSpec.kt
@@ -143,6 +143,10 @@ abstract class HybridVideoPlayerSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
+  abstract fun release(): Unit
+  
+  @DoNotStrip
+  @Keep
   abstract fun initialize(): Promise<Unit>
   
   @DoNotStrip

--- a/packages/react-native-video/nitrogen/generated/ios/c++/HybridVideoPlayerSpecSwift.hpp
+++ b/packages/react-native-video/nitrogen/generated/ios/c++/HybridVideoPlayerSpecSwift.hpp
@@ -188,6 +188,12 @@ namespace margelo::nitro::video {
         std::rethrow_exception(__result.error());
       }
     }
+    inline void release() override {
+      auto __result = _swiftPart.release();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+    }
     inline std::shared_ptr<Promise<void>> initialize() override {
       auto __result = _swiftPart.initialize();
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-video/nitrogen/generated/ios/swift/HybridVideoPlayerSpec.swift
+++ b/packages/react-native-video/nitrogen/generated/ios/swift/HybridVideoPlayerSpec.swift
@@ -32,6 +32,7 @@ public protocol HybridVideoPlayerSpec_protocol: HybridObject {
   func replaceSourceAsync(source: Variant_NullType__any_HybridVideoPlayerSourceSpec_?) throws -> Promise<Void>
   func getAvailableTextTracks() throws -> [TextTrack]
   func selectTextTrack(textTrack: Variant_NullType_TextTrack?) throws -> Void
+  func release() throws -> Void
   func initialize() throws -> Promise<Void>
   func preload() throws -> Promise<Void>
   func play() throws -> Void

--- a/packages/react-native-video/nitrogen/generated/ios/swift/HybridVideoPlayerSpec_cxx.swift
+++ b/packages/react-native-video/nitrogen/generated/ios/swift/HybridVideoPlayerSpec_cxx.swift
@@ -370,6 +370,17 @@ open class HybridVideoPlayerSpec_cxx {
   }
   
   @inline(__always)
+  public final func release() -> bridge.Result_void_ {
+    do {
+      try self.__implementation.release()
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func initialize() -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
       let __result = try self.__implementation.initialize()

--- a/packages/react-native-video/nitrogen/generated/shared/c++/HybridVideoPlayerSpec.cpp
+++ b/packages/react-native-video/nitrogen/generated/shared/c++/HybridVideoPlayerSpec.cpp
@@ -43,6 +43,7 @@ namespace margelo::nitro::video {
       prototype.registerHybridMethod("replaceSourceAsync", &HybridVideoPlayerSpec::replaceSourceAsync);
       prototype.registerHybridMethod("getAvailableTextTracks", &HybridVideoPlayerSpec::getAvailableTextTracks);
       prototype.registerHybridMethod("selectTextTrack", &HybridVideoPlayerSpec::selectTextTrack);
+      prototype.registerHybridMethod("release", &HybridVideoPlayerSpec::release);
       prototype.registerHybridMethod("initialize", &HybridVideoPlayerSpec::initialize);
       prototype.registerHybridMethod("preload", &HybridVideoPlayerSpec::preload);
       prototype.registerHybridMethod("play", &HybridVideoPlayerSpec::play);

--- a/packages/react-native-video/nitrogen/generated/shared/c++/HybridVideoPlayerSpec.hpp
+++ b/packages/react-native-video/nitrogen/generated/shared/c++/HybridVideoPlayerSpec.hpp
@@ -98,6 +98,7 @@ namespace margelo::nitro::video {
       virtual std::shared_ptr<Promise<void>> replaceSourceAsync(const std::optional<std::variant<nitro::NullType, std::shared_ptr<HybridVideoPlayerSourceSpec>>>& source) = 0;
       virtual std::vector<TextTrack> getAvailableTextTracks() = 0;
       virtual void selectTextTrack(const std::optional<std::variant<nitro::NullType, TextTrack>>& textTrack) = 0;
+      virtual void release() = 0;
       virtual std::shared_ptr<Promise<void>> initialize() = 0;
       virtual std::shared_ptr<Promise<void>> preload() = 0;
       virtual void play() = 0;

--- a/packages/react-native-video/src/spec/nitro/VideoPlayer.nitro.ts
+++ b/packages/react-native-video/src/spec/nitro/VideoPlayer.nitro.ts
@@ -23,6 +23,12 @@ export interface VideoPlayer
    */
   showNotificationControls: boolean;
 
+  /**
+   * Replace the current source of the player.
+   * @param source - The new source of the video.
+   * @note If you want to clear the source, you can pass null. It have same effect as {@link release}.
+   * see {@link VideoPlayerSourceBase}
+   */
   replaceSourceAsync(source: VideoPlayerSource | null): Promise<void>;
 
   /**
@@ -36,6 +42,11 @@ export interface VideoPlayer
    * @param textTrack - Text track to select, or null to unselect current track
    */
   selectTextTrack(textTrack: TextTrack | null): void;
+
+  /**
+   * Releases the player's native resources and releases native state.
+   */
+  release(): void;
 }
 
 export interface VideoPlayerFactory

--- a/packages/react-native-video/src/spec/nitro/VideoPlayer.nitro.ts
+++ b/packages/react-native-video/src/spec/nitro/VideoPlayer.nitro.ts
@@ -26,7 +26,7 @@ export interface VideoPlayer
   /**
    * Replace the current source of the player.
    * @param source - The new source of the video.
-   * @note If you want to clear the source, you can pass null. It have same effect as {@link release}.
+   * @note If you want to clear the source, you can pass null. It has the same effect as {@link release}.
    * see {@link VideoPlayerSourceBase}
    */
   replaceSourceAsync(source: VideoPlayerSource | null): Promise<void>;


### PR DESCRIPTION
## Summary
Until now, when player was released we call [`dispose()` to clear native object, but once `dispose()` is called we cannot access any properties](https://nitro.margelo.com/docs/hybrid-objects#dispose). 

This cause crashes when player is used with events:

```mermaid
sequenceDiagram
    autonumber
    participant RN as React Native
    participant App as App Logic
    participant Player as HybridVideoPlayer

    Player->>RN: Event is called (scheduled by RN)
    App->>Player: Release player (dispose())
    Note right of Player: Resources freed and references invalid
    App-->>RN: JS callback scheduled/executed
    RN->>App: Run JS callback
    App->>Player: Access player reference
    Player-->>App: Crash due to disposed instance
    Note over App,Player: Access after dispose() triggers crash
```

This PR changes this behaviour. Now we don't call `dispose()`, instead we set hybrid player to undefined and we let GC to clean it when needed. We throw "specific" error when, player being accessed after release. This fixes uncontrolled crashes