### PR TITLE
chore: update lefthook configuration

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,12 @@
+glob_matcher: doublestar
+
 pre-commit:
   parallel: true
   commands:
     lint:
-      glob: "*.{js,ts,jsx,tsx}"
-      exclude: "docs/**/*"
+      glob: "**/*.{js,ts,jsx,tsx}"
+      exclude:
+        - "docs/**"
       run: bun lint
     lint-docs:
       # using @widlarzgroup/eslint-plugin-docusaurus for CSS variable validation
@@ -11,7 +14,7 @@ pre-commit:
       glob: "**/*.{js,ts,jsx,tsx,css}"
       run: bun run lint
     types:
-      glob: "*.{js,ts,jsx,tsx}"
+      glob: "**/*.{js,ts,jsx,tsx}"
       run: bun typecheck
 commit-msg:
   parallel: true


### PR DESCRIPTION
Switched Lefthook template to glob_matcher: doublestar for more standard / predictable glob behavior.
This also fixes an issue where changing only files in docs/ could trigger two rules unexpectedly.

More context: https://github.com/callstack/react-native-builder-bob/discussions/920