### PR TITLE
fix(ios): fixed audio focus change on iOS

### DIFF
--- a/packages/react-native-video/ios/core/VideoManager.swift
+++ b/packages/react-native-video/ios/core/VideoManager.swift
@@ -155,7 +155,7 @@ class VideoManager {
     
     configureAudioSession()
   }
-  
+
   private func configureAudioSession() {
     let audioSession = AVAudioSession.sharedInstance()
     var audioSessionCategoryOptions: AVAudioSession.CategoryOptions = audioSession.categoryOptions
@@ -194,17 +194,19 @@ class VideoManager {
     )
     
     let audioMixingMode = determineAudioMixingMode()
-    
+
+  
+    audioSessionCategoryOptions.remove(.duckOthers)
+    audioSessionCategoryOptions.remove(.mixWithOthers)
+
     switch audioMixingMode {
     case .mixwithothers:
       audioSessionCategoryOptions.insert(.mixWithOthers)
-    case .donotmix:
-      audioSessionCategoryOptions.remove(.mixWithOthers)
     case .duckothers:
       audioSessionCategoryOptions.insert(.duckOthers)
-    case .auto:
-      audioSessionCategoryOptions.remove(.mixWithOthers)
-      audioSessionCategoryOptions.remove(.duckOthers)
+    case .auto, .donotmix:
+      break
+      // Do nothing as we already cleared the options
     }
     
     do {

--- a/packages/react-native-video/ios/core/VideoManager.swift
+++ b/packages/react-native-video/ios/core/VideoManager.swift
@@ -205,8 +205,8 @@ class VideoManager {
     case .duckothers:
       audioSessionCategoryOptions.insert(.duckOthers)
     case .auto, .donotmix:
-      break
       // Do nothing as we already cleared the options
+      break
     }
     
     do {


### PR DESCRIPTION
The previous implementation of audio mixing mode selection had a bug where switching between different modes (e.g., from .mixWithOthers to .doNotMix) did not consistently remove the previously set options. This was because the switch statement only handled removals in specific cases, potentially leaving stale flags in audioSessionCategoryOptions.