### PR TITLE
fix(android): Conditionally add/remove PIP mode change listener

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -58,7 +58,7 @@ object PictureInPictureUtil {
         if (view.enterPictureInPictureOnLeave) {
             activity.addOnPictureInPictureModeChangedListener(onPictureInPictureModeChanged)
         }
-        
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             activity.addOnUserLeaveHintListener(onUserLeaveHintCallback)
         }
@@ -69,7 +69,7 @@ object PictureInPictureUtil {
                 if (view.enterPictureInPictureOnLeave) {
                     removeOnPictureInPictureModeChangedListener(onPictureInPictureModeChanged)
                 }
-                
+
                 removeOnUserLeaveHintListener(onUserLeaveHintCallback)
             }
         }

--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -55,8 +55,10 @@ object PictureInPictureUtil {
             }
         }
 
-        activity.addOnPictureInPictureModeChangedListener(onPictureInPictureModeChanged)
-
+        if (view.enterPictureInPictureOnLeave) {
+            activity.addOnPictureInPictureModeChangedListener(onPictureInPictureModeChanged)
+        }
+        
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             activity.addOnUserLeaveHintListener(onUserLeaveHintCallback)
         }
@@ -64,7 +66,10 @@ object PictureInPictureUtil {
         // @TODO convert to lambda when ReactExoplayerView migrated
         return Runnable {
             with(activity) {
-                removeOnPictureInPictureModeChangedListener(onPictureInPictureModeChanged)
+                if (view.enterPictureInPictureOnLeave) {
+                    removeOnPictureInPictureModeChangedListener(onPictureInPictureModeChanged)
+                }
+                
                 removeOnUserLeaveHintListener(onUserLeaveHintCallback)
             }
         }


### PR DESCRIPTION
This fix resolves an issue with PiP during a call.
If a Video component is rendered in another tab and the call screen is opened, then the app is sent to the background, the PiP window may show video frames or a black screen, even though PiP is not enabled for the video component.