### PR TITLE
fix: access `AudioFocusChangeListener` on main thread

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/AudioFocusManager.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/AudioFocusManager.kt
@@ -29,28 +29,30 @@ class AudioFocusManager() {
   }
 
   private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
-    when (focusChange) {
-      AudioManager.AUDIOFOCUS_GAIN -> {
-        unDuckActivePlayers()
-      }
-      AudioManager.AUDIOFOCUS_LOSS -> {
-        pauseActivePlayers()
-        currentMixAudioMode = null
-        audioFocusRequest = null
-      }
-      AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
-        val mixAudioMode = determineRequiredMixMode()
-        if (mixAudioMode != MixAudioMode.MIXWITHOTHERS) {
+    Threading.runOnMainThread {
+      when (focusChange) {
+        AudioManager.AUDIOFOCUS_GAIN -> {
+          unDuckActivePlayers()
+        }
+        AudioManager.AUDIOFOCUS_LOSS -> {
           pauseActivePlayers()
           currentMixAudioMode = null
           audioFocusRequest = null
         }
-      }
-      AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
-        val mixAudioMode = determineRequiredMixMode()
-        when (mixAudioMode) {
-          MixAudioMode.DONOTMIX -> pauseActivePlayers()
-          else -> duckActivePlayers()
+        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+          val mixAudioMode = determineRequiredMixMode()
+          if (mixAudioMode != MixAudioMode.MIXWITHOTHERS) {
+            pauseActivePlayers()
+            currentMixAudioMode = null
+            audioFocusRequest = null
+          }
+        }
+        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
+          val mixAudioMode = determineRequiredMixMode()
+          when (mixAudioMode) {
+            MixAudioMode.DONOTMIX -> pauseActivePlayers()
+            else -> duckActivePlayers()
+          }
         }
       }
     }


### PR DESCRIPTION
wrap audio focus listener in runOnMainThread to prevent crashes

the audio focus callback was invoked on a background thread, but ExoPlayer 
requires main thread access - missing the wrapper caused crashes