### PR TITLE
fix: video not loading when external subtitles are malformed

### DIFF
--- a/packages/react-native-video/ios/core/Utils/ExternalSubtitlesUtils.swift
+++ b/packages/react-native-video/ios/core/Utils/ExternalSubtitlesUtils.swift
@@ -67,11 +67,18 @@ enum ExternalSubtitlesUtils {
           withMediaType: .text,
           preferredTrackID: kCMPersistentTrackID_Invalid
         ) {
-          try compositionTextTrack.insertTimeRange(
-            CMTimeRange(start: .zero, duration: textTrack.timeRange.duration),
-            of: textTrack,
-            at: .zero
-          )
+          do {
+            try compositionTextTrack.insertTimeRange(
+              CMTimeRange(start: .zero, duration: textTrack.timeRange.duration),
+              of: textTrack,
+              at: .zero
+            )
+          } catch {
+            print(
+              "[ReactNativeVideo] Failed to insert text track into composition: \(error.localizedDescription). Language: \(textTrack.languageCode ?? "unknown"). Continuing without this subtitle track."
+            )
+            continue
+          }
 
           compositionTextTrack.languageCode = textTrack.languageCode
           compositionTextTrack.isEnabled = true


### PR DESCRIPTION
Fixes an issue where video playback failed in release mode when external subtitles were malformed (e.g. end time earlier than start time). AVPlayer is unable to parse this, causing playback to stop. The fix catches the AVFoundation error and gracefully falls back to playing the video without external subtitles instead of blocking playback