### PR TITLE
fix(ios): handle fullscreen transition cancellation events

### DIFF
--- a/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
+++ b/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
@@ -123,9 +123,16 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
     willEndFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
   ) {
     delegate?.willExitFullscreen()
-    
-    coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+
+    coordinator.animate(alongsideTransition: nil) { [weak self] context in
       guard let self = self else { return }
+        
+      if context.isCancelled {
+        self.delegate?.willEnterFullscreen()
+
+        return
+      }
+
       self.delegate?.onFullscreenChange(false)
     }
   }
@@ -135,9 +142,16 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
     willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
   ) {
     delegate?.willEnterFullscreen()
-    
-    coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+
+    coordinator.animate(alongsideTransition: nil) { [weak self] context in
       guard let self = self else { return }
+
+      if context.isCancelled {
+        self.delegate?.willExitFullscreen()
+
+        return
+      }
+
       self.delegate?.onFullscreenChange(true)
     }
   }


### PR DESCRIPTION
### Description

This PR fixes an edge case in `AVPlayerViewController` fullscreen transitions during the interactive swipe-to-dismiss gesture.

When the user starts exiting fullscreen (swipe down), we emit `willExitFullscreen`. If the user reverses the swipe before releasing (transition gets cancelled), UIKit cancels the exit and returns to fullscreen. Previously, this could lead to incorrect/imbalanced `willEnter/willExit` events or a false `onFullscreenChange` signal.

### What changed

* Handle `UIViewControllerTransitionCoordinatorContext.isCancelled` in fullscreen transition callbacks.
* When an interactive **exit** is cancelled, emit the corresponding **enter** “will” event to keep `willEnterFullscreen` / `willExitFullscreen` balanced.
* Prevent committing fullscreen state changes and `onFullscreenChange(false)` when the exit is cancelled.
* Keep `onFullscreenChange` semantics: emitted only when the fullscreen state is actually committed after the animation.

### Why

This ensures predictable fullscreen event sequences for consumers:

* Apps relying on `willEnter/willExit` get consistent paired signals even when gestures are reversed.
* Apps relying on `onFullscreenChange` only receive state changes that actually happen.

### Testing

* Start fullscreen → swipe down to exit → reverse swipe before releasing → verify events remain consistent and fullscreen state stays unchanged