### PR TITLE
fix(ios): notification controls

### DIFF
--- a/packages/react-native-video/ios/core/Extensions/AVMetadataItem+make.swift
+++ b/packages/react-native-video/ios/core/Extensions/AVMetadataItem+make.swift
@@ -1,3 +1,10 @@
+//
+//  AVMetadataItem+make.swift
+//  ReactNativeVideo
+//
+//  Created by Kamil Moskała on 06/02/2026.
+//
+
 import AVFoundation
 
 extension AVMetadataItem {

--- a/packages/react-native-video/ios/core/Extensions/AVMetadataItem+make.swift
+++ b/packages/react-native-video/ios/core/Extensions/AVMetadataItem+make.swift
@@ -1,0 +1,11 @@
+import AVFoundation
+
+extension AVMetadataItem {
+  static func make(identifier: AVMetadataIdentifier, value: NSObjectProtocol & NSCopying) -> AVMutableMetadataItem {
+    let item = AVMutableMetadataItem()
+    item.identifier = identifier
+    item.value = value
+    item.extendedLanguageTag = "und"
+    return item
+  }
+}

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -218,10 +218,13 @@ class NowPlayingInfoCenterManager {
   }
 
   public func updateNowPlayingInfo() {
-    guard let player = currentPlayer, let currentItem = player.currentItem
-    else {
+    guard let player = currentPlayer else {
       invalidateCommandTargets()
       MPNowPlayingInfoCenter.default().nowPlayingInfo = [:]
+      return
+    }
+
+    guard let currentItem = player.currentItem else {
       return
     }
 

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -114,7 +114,7 @@ class NowPlayingInfoCenterManager {
     updateNowPlayingInfo()
     playbackObserver = player.addPeriodicTimeObserver(
       forInterval: CMTime(value: 1, timescale: 4),
-      queue: .global(),
+      queue: .main,
       using: { [weak self] _ in
         self?.updateNowPlayingInfo()
       }

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -414,7 +414,10 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
       // Load artwork in background to not block player initialization
       if let imageUri, let imageUrl = URL(string: imageUri) {
         Task { [weak playerItem] in
-          guard let (data, _) = try? await URLSession.shared.data(from: imageUrl) else { return }
+          guard let (data, _) = try? await URLSession.shared.data(from: imageUrl) else {
+            print("[RNV] Failed to load artwork from: \(imageUrl)")
+            return
+          }
           DispatchQueue.main.async {
             guard let playerItem else { return }
             playerItem.externalMetadata = playerItem.externalMetadata + [.make(identifier: .commonIdentifierArtwork, value: data as NSData)]

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -421,6 +421,8 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
             NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
           }
         }
+      } else if let imageUri {
+        print("[RNV] Invalid imageUri for artwork: \(imageUri)")
       }
     }
 


### PR DESCRIPTION
 ### Summary

  - Fix paused video disappearing from notification center - periodic observer was running on a background queue instead of main queue, causing unreliable NowPlayingInfo updates
  - Fix custom metadata (title, artist, artwork) not appearing in Control Center - externalMetadata was never set on
  AVPlayerItem, so NowPlayingInfoCenterManager had nothing to read
  - Fix artwork loading blocking player initialization - artwork image is now downloaded asynchronously and NowPlayingInfo is updated once ready
  - Fix showNotificationControls not working when set during useVideoPlayer callback - updateNowPlayingInfo() was immediately invalidating command targets because currentItem hadn't loaded yet

  ### Test plan

  - Pause video and verify it remains visible in notification center / Control Center
  - Set metadata (title, artist, imageUri) in source config and verify it appears in Control Center
  - Verify artwork appears in Control Center after a short delay (async load)
  - Set showNotificationControls = true in useVideoPlayer callback and verify controls appear
  - Verify controls still work when set later (mid-playback)
  - Verify cleanup works correctly when player is released