### PR TITLE
fix(ios): prevent EXC_BREAKPOINT crash in HybridVideoPlayer.release()

### DIFF
--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -32,6 +32,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
   }
   var playerObserver: VideoPlayerObserver?
   private let sourceLoader = SourceLoader()
+  private var isReleased = false
 
   init(source: (any HybridVideoPlayerSourceSpec)) throws {
     self.source = source
@@ -61,7 +62,27 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
   }
 
   deinit {
-    release()
+    // Minimal cleanup only — ARC handles stored property deallocation.
+    // Do NOT call release() here: it may already have been called from JS,
+    // and re-entering it during deinit risks accessing partially torn-down
+    // Nitro bridge state (EXC_BREAKPOINT on iOS 26+).
+    let capturedPlayer = self.player
+    let capturedObserver = self.playerObserver
+
+    let teardown = {
+      capturedObserver?.invalidatePlayerItemObservers()
+      capturedObserver?.invalidatePlayerObservers()
+      NowPlayingInfoCenterManager.shared.removePlayer(player: capturedPlayer)
+      capturedPlayer.replaceCurrentItem(with: nil)
+    }
+
+    if Thread.isMainThread {
+      teardown()
+    } else {
+      DispatchQueue.main.sync(execute: teardown)
+    }
+
+    VideoManager.shared.unregister(player: self)
   }
 
   // MARK: - Hybrid Impl
@@ -204,25 +225,41 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
   }
 
   func release() {
+    guard !isReleased else { return }
+    isReleased = true
+
     sourceLoader.cancelSync()
-    NowPlayingInfoCenterManager.shared.removePlayer(player: player)
 
     try? _eventEmitter?.clearAllListeners()
-
-    self.playerItem = nil
 
     if let source = self.source as? HybridVideoPlayerSource {
       source.releaseAsset()
     }
 
-    // Clear player observer
-    playerObserver?.invalidatePlayerItemObservers()
-    playerObserver?.invalidatePlayerObservers()
+    // AVPlayer and KVO observers must be torn down on the main thread to
+    // avoid data races with periodic/KVO callbacks dispatched to .main.
+    // release() is called from the JS thread (via Nitro bridge) while
+    // observer callbacks fire on the main thread concurrently.
+    let capturedPlayer = self.player
+    let capturedObserver = self.playerObserver
+
+    self.playerItem = nil
     self.playerObserver = nil
 
-    self.player.replaceCurrentItem(with: nil)
-    status = .idle
+    let teardown = {
+      capturedObserver?.invalidatePlayerItemObservers()
+      capturedObserver?.invalidatePlayerObservers()
+      NowPlayingInfoCenterManager.shared.removePlayer(player: capturedPlayer)
+      capturedPlayer.replaceCurrentItem(with: nil)
+    }
 
+    if Thread.isMainThread {
+      teardown()
+    } else {
+      DispatchQueue.main.sync(execute: teardown)
+    }
+
+    status = .idle
     VideoManager.shared.unregister(player: self)
   }
 

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -51,7 +51,9 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
           self.playerItem = try await self.sourceLoader.load {
             try await self.initializePlayerItem()
           }
-          self.player.replaceCurrentItem(with: self.playerItem)
+          await MainActor.run {
+            self.player.replaceCurrentItem(with: self.playerItem)
+          }
         } catch {
           // Ignore cancellation errors during initialization
         }
@@ -214,7 +216,9 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
         self.playerItem = try await self.sourceLoader.load {
           try await self.initializePlayerItem()
         }
-        self.player.replaceCurrentItem(with: self.playerItem)
+        await MainActor.run {
+          self.player.replaceCurrentItem(with: self.playerItem)
+        }
       } catch {
         if error is CancellationError {
           throw PlayerError.cancelled.error()
@@ -286,7 +290,9 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
         }
         self.playerItem = playerItem
 
-        self.player.replaceCurrentItem(with: playerItem)
+        await MainActor.run {
+          self.player.replaceCurrentItem(with: playerItem)
+        }
         promise.resolve(withResult: ())
       } catch {
         if error is CancellationError {
@@ -378,7 +384,9 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
           self.playerItem = try await self.sourceLoader.load {
             try await self.initializePlayerItem()
           }
-          self.player.replaceCurrentItem(with: self.playerItem)
+          await MainActor.run {
+            self.player.replaceCurrentItem(with: self.playerItem)
+          }
           NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
           promise.resolve(withResult: ())
         } catch {


### PR DESCRIPTION
## Summary

Fixes a crash (`EXC_BREAKPOINT`) in `HybridVideoPlayer.release()` observed on iOS 26 when the method is called from the JS thread via the Nitro bridge during Hermes microtask processing.

**Crashlytics stack trace:**
```
Crashed: com.facebook.react.runtime.JavaScript
EXC_BREAKPOINT 0x0000000102ab08b4

0  AppReel  HybridVideoPlayer.release() + 37032
2  protocol witness for HybridVideoPlayerSpec_protocol.release()
3  HybridVideoPlayerSpec_cxx.swift:375 — HybridVideoPlayerSpec_cxx.release()
4  Result.hpp:140 — HybridVideoPlayerSpecSwift::release()
5  jsi.h:1507 — HybridFunction::createHybridFunction(...)
...
15 hermes — drainMicrotasks
```

Two issues are fixed:

- **Double-release**: `release()` is called twice — once from JS cleanup (`useVideoPlayer` unmount → `__destroy()` → `player.release()`) and again from Swift `deinit` when the Nitro GC later collects the hybrid object. The second invocation accesses already-cleared state (event emitter, observers). An `isReleased` flag now prevents re-entry. `deinit` no longer calls `release()` — it performs only minimal observer/player cleanup directly.

- **Thread safety**: `release()` runs on the JS thread (via Nitro/JSI bridge), but `VideoPlayerObserver` registers KVO observers and a periodic time observer that fire callbacks on the **main thread**. Concurrent access from both threads corrupts internal state. AVPlayer operations and observer invalidation in `release()` (and `deinit`) are now dispatched to the main thread via `DispatchQueue.main.sync` when not already there.

## Environment
- iOS 26 (beta)
- react-native-video 7.0.0-beta.6
- Hermes engine
- 2 crash events affecting 2 users in production
