### PR TITLE
fix(ios): restore inline UI after PIP stop to prevent black screen

### DIFF
--- a/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
+++ b/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
@@ -117,6 +117,13 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
   func playerViewControllerWillStopPictureInPicture(_: AVPlayerViewController) {
     delegate?.willExitPictureInPicture()
   }
+
+  func playerViewControllerRestoreUserInterfaceForPictureInPictureStop(
+    _ playerViewController: AVPlayerViewController,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
+    completionHandler(true)
+  }
   
   func playerViewController(
     _: AVPlayerViewController,

--- a/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
+++ b/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
@@ -122,7 +122,8 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
     _ playerViewController: AVPlayerViewController,
     completionHandler: @escaping (Bool) -> Void
   ) {
-    completionHandler(true)
+    let isViewAttached = view?.window != nil
+    completionHandler(isViewAttached)
   }
   
   func playerViewController(


### PR DESCRIPTION
VideoComponentViewObserver did not implement `playerViewControllerRestoreUserInterfaceForPictureInPictureStop` - an AVPlayerViewControllerDelegate method called by iOS just before the PIP window closes to let the app restore the UI that should receive the player layer back.

  From Apple's docs - If you do not implement this method, the system calls the completion handler with the value
  false

  completionHandler(false) tells iOS that the app failed to restore its UI, so iOS skips the
  animation that moves the player layer from the PIP window back to the inline view - leaving a
  black rectangle in its place.

 #### Fix:

  Implemented the missing delegate method in VideoComponentViewObserver