### PR TITLE
fix(ios): notification controls flow

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1565,7 +1565,7 @@ PODS:
     - React-logger (= 0.77.3)
     - React-perflogger (= 0.77.3)
     - React-utils (= 0.77.3)
-  - ReactNativeVideo (7.0.0-beta.1):
+  - ReactNativeVideo (7.0.0-beta.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1587,7 +1587,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ReactNativeVideoDrm (7.0.0-beta.1):
+  - ReactNativeVideoDrm (7.0.0-beta.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1904,8 +1904,8 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 31015410a4a53b9fd0a908ad4d6e3e2b9a25086a
   ReactCodegen: 53316394e985ded1babc7f143c90c77d2bb1b43c
   ReactCommon: bf4612cba0fa356b529385029f470d5529dddde4
-  ReactNativeVideo: 10dd0a47f8228b41565a3efb13df5b323633b590
-  ReactNativeVideoDrm: 07b826ab66fd0a00ab3dd3bef2dd2c026e919a9a
+  ReactNativeVideo: de7056e831a46412e81fbf730ef739ec4c7378fe
+  ReactNativeVideoDrm: a83670242cec729b4fb67e7c804ab3300e848b86
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 92f3bb322c40a86b7233b815854730442e01b8c4
 

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -76,6 +76,10 @@ class NowPlayingInfoCenterManager {
     players.remove(player)
 
     if currentPlayer == player {
+      if let playbackObserver {
+        player.removeTimeObserver(playbackObserver)
+        self.playbackObserver = nil
+      }
       currentPlayer = nil
       updateNowPlayingInfo()
     }
@@ -275,8 +279,8 @@ class NowPlayingInfoCenterManager {
       filteredByIdentifier: .commonIdentifierArtwork
     ).first else { return }
 
-    artworkMetadataItem.loadValuesAsynchronously(forKeys: ["value"]) { [weak self] in
-      guard self != nil else { return }
+    artworkMetadataItem.loadValuesAsynchronously(forKeys: ["value"]) { [weak self, weak player] in
+      guard let self, self.currentPlayer === player else { return }
       let imgData = artworkMetadataItem.dataValue
       let image = imgData.flatMap { UIImage(data: $0) } ?? UIImage()
       let artworkItem = MPMediaItemArtwork(boundsSize: image.size) { _ in image }

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -264,8 +264,7 @@ class NowPlayingInfoCenterManager {
       MPMediaItemPropertyTitle: titleItem,
       MPMediaItemPropertyArtist: artistItem,
       MPMediaItemPropertyPlaybackDuration: currentItem.duration.seconds,
-      MPNowPlayingInfoPropertyElapsedPlaybackTime: currentItem.currentTime()
-        .seconds.rounded(),
+      MPNowPlayingInfoPropertyElapsedPlaybackTime: currentItem.currentTime().seconds,
       MPNowPlayingInfoPropertyPlaybackRate: player.rate,
       MPNowPlayingInfoPropertyIsLiveStream: CMTIME_IS_INDEFINITE(
         currentItem.asset.duration

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -57,7 +57,8 @@ class NowPlayingInfoCenterManager {
     observers[player.hashValue] = observePlayers(player: player)
     players.add(player)
 
-    if currentPlayer == nil {
+    // Also take over if the new player is already playing — KVO won't fire since rate hasn't changed
+    if currentPlayer == nil || player.rate != 0 {
       setCurrentPlayer(player: player)
     }
   }

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -17,7 +17,6 @@ class NowPlayingInfoCenterManager {
   private var skipForwardTarget: Any?
   private var skipBackwardTarget: Any?
   private var playbackPositionTarget: Any?
-  private var seekTarget: Any?
   private var togglePlayPauseTarget: Any?
 
   private let remoteCommandCenter = MPRemoteCommandCenter.shared()
@@ -86,7 +85,7 @@ class NowPlayingInfoCenterManager {
         self.playbackObserver = nil
       }
       currentPlayer = nil
-      updateNowPlayingInfo()
+      updatePlaybackState()
     }
   }
 
@@ -124,7 +123,7 @@ class NowPlayingInfoCenterManager {
       forInterval: CMTime(value: 1, timescale: 4),
       queue: .main,
       using: { [weak self] _ in
-        self?.updateNowPlayingInfo()
+        self?.updatePlaybackState()
       }
     )
   }
@@ -226,13 +225,12 @@ class NowPlayingInfoCenterManager {
   }
 
   public func updateNowPlayingInfo() {
-    guard let player = currentPlayer else {
-      invalidateCommandTargets()
-      MPNowPlayingInfoCenter.default().nowPlayingInfo = [:]
-      return
-    }
+    updateStaticInfo()
+    updatePlaybackState()
+  }
 
-    guard let currentItem = player.currentItem else {
+  func updateStaticInfo() {
+    guard let player = currentPlayer, let currentItem = player.currentItem else {
       return
     }
 
@@ -241,42 +239,29 @@ class NowPlayingInfoCenterManager {
     // When the metadata has the tag "iTunSMPB" or "iTunNORM" then the metadata is not converted correctly and comes [nil, nil, ...]
     // This leads to a crash of the app
     let metadata: [AVMetadataItem] = {
-
       let common = processMetadataItems(currentItem.asset.commonMetadata)
       let external = processMetadataItems(currentItem.externalMetadata)
-
       return Array(common.merging(external) { _, new in new }.values)
     }()
 
-    let titleItem =
-      AVMetadataItem.metadataItems(
-        from: metadata,
-        filteredByIdentifier: .commonIdentifierTitle
-      ).first?.stringValue ?? ""
+    let title = AVMetadataItem.metadataItems(
+      from: metadata,
+      filteredByIdentifier: .commonIdentifierTitle
+    ).first?.stringValue ?? ""
 
-    let artistItem =
-      AVMetadataItem.metadataItems(
-        from: metadata,
-        filteredByIdentifier: .commonIdentifierArtist
-      ).first?.stringValue ?? ""
+    let artist = AVMetadataItem.metadataItems(
+      from: metadata,
+      filteredByIdentifier: .commonIdentifierArtist
+    ).first?.stringValue ?? ""
 
-    let newNowPlayingInfo: [String: Any] = [
-      MPMediaItemPropertyTitle: titleItem,
-      MPMediaItemPropertyArtist: artistItem,
-      MPMediaItemPropertyPlaybackDuration: currentItem.duration.seconds,
-      MPNowPlayingInfoPropertyElapsedPlaybackTime: currentItem.currentTime().seconds,
-      MPNowPlayingInfoPropertyPlaybackRate: player.rate,
-      MPNowPlayingInfoPropertyIsLiveStream: CMTIME_IS_INDEFINITE(
-        currentItem.asset.duration
-      ),
-    ]
-    let currentNowPlayingInfo =
-      MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+    var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+    info[MPMediaItemPropertyTitle] = title
+    info[MPMediaItemPropertyArtist] = artist
+    info[MPMediaItemPropertyPlaybackDuration] = currentItem.duration.seconds
+    info[MPNowPlayingInfoPropertyIsLiveStream] = CMTIME_IS_INDEFINITE(currentItem.asset.duration)
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = info
 
-    MPNowPlayingInfoCenter.default().nowPlayingInfo =
-      currentNowPlayingInfo.merging(newNowPlayingInfo) { _, new in new }
-
-    // Load artwork asynchronously so notification controls appear immediately
+    // Load artwork asynchronously so notification controls appear immediately.
     guard let artworkMetadataItem = AVMetadataItem.metadataItems(
       from: metadata,
       filteredByIdentifier: .commonIdentifierArtwork
@@ -293,6 +278,21 @@ class NowPlayingInfoCenterManager {
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
       }
     }
+  }
+
+  func updatePlaybackState() {
+    guard let player = currentPlayer else {
+      invalidateCommandTargets()
+      MPNowPlayingInfoCenter.default().nowPlayingInfo = [:]
+      return
+    }
+
+    guard let currentItem = player.currentItem else { return }
+
+    var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+    info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentItem.currentTime().seconds
+    info[MPNowPlayingInfoPropertyPlaybackRate] = player.rate
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = info
   }
 
   private func findNewCurrentPlayer() {

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -85,7 +85,10 @@ class NowPlayingInfoCenterManager {
         self.playbackObserver = nil
       }
       currentPlayer = nil
-      updatePlaybackState()
+      findNewCurrentPlayer()
+      if currentPlayer == nil {
+        updatePlaybackState()
+      }
     }
   }
 

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -75,6 +75,11 @@ class NowPlayingInfoCenterManager {
     observers.removeValue(forKey: player.hashValue)
     players.remove(player)
 
+    if players.allObjects.isEmpty {
+      cleanup()
+      return
+    }
+
     if currentPlayer == player {
       if let playbackObserver {
         player.removeTimeObserver(playbackObserver)
@@ -82,10 +87,6 @@ class NowPlayingInfoCenterManager {
       }
       currentPlayer = nil
       updateNowPlayingInfo()
-    }
-
-    if players.allObjects.isEmpty {
-      cleanup()
     }
   }
 
@@ -95,7 +96,9 @@ class NowPlayingInfoCenterManager {
 
     if let playbackObserver {
       currentPlayer?.removeTimeObserver(playbackObserver)
+      self.playbackObserver = nil
     }
+    currentPlayer = nil
 
     invalidateCommandTargets()
 

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -267,12 +267,12 @@ class NowPlayingInfoCenterManager {
       filteredByIdentifier: .commonIdentifierArtwork
     ).first else { return }
 
-    artworkMetadataItem.loadValuesAsynchronously(forKeys: ["value"]) { [weak self, weak player] in
-      guard let self, self.currentPlayer === player else { return }
-      let imgData = artworkMetadataItem.dataValue
-      let image = imgData.flatMap { UIImage(data: $0) } ?? UIImage()
+    Task { [weak self, weak player] in
+      guard let data = try? await artworkMetadataItem.load(.dataValue),
+            let image = UIImage(data: data) else { return }
       let artworkItem = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
-      DispatchQueue.main.async {
+      await MainActor.run {
+        guard let self, self.currentPlayer === player else { return }
         var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
         info[MPMediaItemPropertyArtwork] = artworkItem
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -263,6 +263,7 @@ class NowPlayingInfoCenterManager {
     info[MPMediaItemPropertyArtist] = artist
     info[MPMediaItemPropertyPlaybackDuration] = currentItem.duration.seconds
     info[MPNowPlayingInfoPropertyIsLiveStream] = CMTIME_IS_INDEFINITE(currentItem.asset.duration)
+    info[MPMediaItemPropertyArtwork] = nil // Clear artwork from previous item; will be loaded asynchronously below
     MPNowPlayingInfoCenter.default().nowPlayingInfo = info
 
     // Load artwork asynchronously so notification controls appear immediately.
@@ -271,12 +272,13 @@ class NowPlayingInfoCenterManager {
       filteredByIdentifier: .commonIdentifierArtwork
     ).first else { return }
 
-    Task { [weak self, weak player] in
+    Task { [weak self, weak player, weak currentItem] in
       guard let data = try? await artworkMetadataItem.load(.dataValue),
             let image = UIImage(data: data) else { return }
       let artworkItem = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
       await MainActor.run {
-        guard let self, self.currentPlayer === player else { return }
+        guard let self, self.currentPlayer === player,
+              self.currentPlayer?.currentItem === currentItem else { return }
         var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
         info[MPMediaItemPropertyArtwork] = artworkItem
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -47,7 +47,7 @@ class NowPlayingInfoCenterManager {
       return
     }
 
-    if receivingRemoteControlEvents == false {
+    if !receivingRemoteControlEvents {
       receivingRemoteControlEvents = true
     }
 

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -113,6 +113,7 @@ class NowPlayingInfoCenterManager {
 
     if let playbackObserver {
       currentPlayer?.removeTimeObserver(playbackObserver)
+      self.playbackObserver = nil
     }
 
     currentPlayer = player

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -233,6 +233,11 @@ class NowPlayingInfoCenterManager {
     updatePlaybackState()
   }
 
+  func updateStaticInfo(ifCurrentItem playerItem: AVPlayerItem) {
+    guard currentPlayer?.currentItem === playerItem else { return }
+    updateStaticInfo()
+  }
+
   func updateStaticInfo() {
     guard let player = currentPlayer, let currentItem = player.currentItem else {
       return

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -303,6 +303,7 @@ class NowPlayingInfoCenterManager {
     var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
     info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentItem.currentTime().seconds
     info[MPNowPlayingInfoPropertyPlaybackRate] = player.rate
+    info[MPMediaItemPropertyPlaybackDuration] = currentItem.duration.seconds
     MPNowPlayingInfoCenter.default().nowPlayingInfo = info
   }
 

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -252,19 +252,9 @@ class NowPlayingInfoCenterManager {
         filteredByIdentifier: .commonIdentifierArtist
       ).first?.stringValue ?? ""
 
-    // I have some issue with this - setting artworkItem when it not set dont return nil but also is crashing application
-    // this is very hacky workaround for it
-    let imgData = AVMetadataItem.metadataItems(
-      from: metadata,
-      filteredByIdentifier: .commonIdentifierArtwork
-    ).first?.dataValue
-    let image = imgData.flatMap { UIImage(data: $0) } ?? UIImage()
-    let artworkItem = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
-
     let newNowPlayingInfo: [String: Any] = [
       MPMediaItemPropertyTitle: titleItem,
       MPMediaItemPropertyArtist: artistItem,
-      MPMediaItemPropertyArtwork: artworkItem,
       MPMediaItemPropertyPlaybackDuration: currentItem.duration.seconds,
       MPNowPlayingInfoPropertyElapsedPlaybackTime: currentItem.currentTime()
         .seconds.rounded(),
@@ -278,6 +268,24 @@ class NowPlayingInfoCenterManager {
 
     MPNowPlayingInfoCenter.default().nowPlayingInfo =
       currentNowPlayingInfo.merging(newNowPlayingInfo) { _, new in new }
+
+    // Load artwork asynchronously so notification controls appear immediately
+    guard let artworkMetadataItem = AVMetadataItem.metadataItems(
+      from: metadata,
+      filteredByIdentifier: .commonIdentifierArtwork
+    ).first else { return }
+
+    artworkMetadataItem.loadValuesAsynchronously(forKeys: ["value"]) { [weak self] in
+      guard self != nil else { return }
+      let imgData = artworkMetadataItem.dataValue
+      let image = imgData.flatMap { UIImage(data: $0) } ?? UIImage()
+      let artworkItem = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+      DispatchQueue.main.async {
+        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+        info[MPMediaItemPropertyArtwork] = artworkItem
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+      }
+    }
   }
 
   private func findNewCurrentPlayer() {

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
@@ -22,7 +22,7 @@ extension HybridVideoPlayer: VideoPlayerObserverDelegate {
 
   func onRateChanged(rate: Float) {
     _eventEmitter?.onPlaybackRateChange(Double(rate))
-    NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
+    NowPlayingInfoCenterManager.shared.updatePlaybackState()
     updateAndEmitPlaybackState()
   }
 

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -421,7 +421,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
           DispatchQueue.main.async {
             guard let playerItem else { return }
             playerItem.externalMetadata = playerItem.externalMetadata + [.make(identifier: .commonIdentifierArtwork, value: data as NSData)]
-            NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
+            NowPlayingInfoCenterManager.shared.updateStaticInfo()
           }
         }
       } else if let imageUri {

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -408,7 +408,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
         }
         if !items.isEmpty {
           playerItem.externalMetadata = items
-          NowPlayingInfoCenterManager.shared.updateStaticInfo()
+          NowPlayingInfoCenterManager.shared.updateStaticInfo(ifCurrentItem: playerItem)
         }
       }
 
@@ -422,7 +422,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
           DispatchQueue.main.async {
             guard let playerItem else { return }
             playerItem.externalMetadata = playerItem.externalMetadata + [.make(identifier: .commonIdentifierArtwork, value: data as NSData)]
-            NowPlayingInfoCenterManager.shared.updateStaticInfo()
+            NowPlayingInfoCenterManager.shared.updateStaticInfo(ifCurrentItem: playerItem)
           }
         }
       } else if let imageUri {

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -408,6 +408,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
         }
         if !items.isEmpty {
           playerItem.externalMetadata = items
+          NowPlayingInfoCenterManager.shared.updateStaticInfo()
         }
       }
 


### PR DESCRIPTION
### Changes

  #### Async artwork loading

  Artwork was loaded synchronously as part of building the nowPlayingInfo dictionary. For large or
  remote artwork, this blocked the entire notification center update - controls didn't appear until
   artwork was ready.

  Artwork is now loaded via loadValuesAsynchronously and merged into nowPlayingInfo after the fact,
   so title, artist, and playback controls appear immediately.

  #### Playback observer not removed on removePlayer

  When the current player was removed, `currentPlayer` was set to `nil` before `cleanup()` ran. cleanup()
   used `currentPlayer?.removeTimeObserver(playbackObserver)` - a no-op on nil. The periodic time
  observer was never removed.

  Fixed by reordering: `cleanup()` is now called before `currentPlayer = nil`, so it still has access
  to the player reference and correctly removes the observer.

  For the case where other players still exist (so cleanup() is not called), the observer is
  removed explicitly before clearing currentPlayer.

  #### Stale artwork callback

  The loadValuesAsynchronously callback used `[weak self] with guard self != nil` - but self is a
  singleton and never deallocates, making the guard a no-op. If the current player changed between
  starting and completing the load, the old artwork would overwrite the new player's info.

  Fixed by capturing player weakly and verifying `self.currentPlayer === player` before applying the
  result.

  #### Minor cleanup
  - Removed `.rounded()` from `MPNowPlayingInfoPropertyElapsedPlaybackTime` - iOS interpolates the
  progress bar using elapsed time + playback rate, rounding only reduced precision
  - `playbackObserver` is now consistently set to `nil` after removal in all code paths
  - r`eceivingRemoteControlEvents == false` → `!receivingRemoteControlEvents`