### PR TITLE
fix: RCTVideoManager crash in bridgeless mode RN 0.84

### DIFF
--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -4,7 +4,8 @@ import React
 @objc(RCTVideoManager)
 class RCTVideoManager: RCTViewManager {
     override func view() -> UIView {
-        return RCTVideo(eventDispatcher: (RCTBridge.current().eventDispatcher() as! RCTEventDispatcher))
+        let eventDispatcher = bridge?.eventDispatcher() as? RCTEventDispatcher
+        return RCTVideo(eventDispatcher: eventDispatcher)
     }
 
     func methodQueue() -> DispatchQueue {


### PR DESCRIPTION
`RCTVideoManager.swift:7` crashes with:
  Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value

Fixes #4845

  The crash occurs because `RCTBridge.current()` returns `nil` in bridgeless mode (on RN 0.84):

  ```swift
// Before (crashes)
RCTVideo(eventDispatcher: (RCTBridge.current().eventDispatcher() as! RCTEventDispatcher))
```
  Root cause

  In bridgeless mode there is no global RCTBridge singleton — RCTBridge.current() returns nil. The
  interop layer provides a RCTBridgeProxy through self.bridge on RCTViewManager instead.

  Fix
```swift
// After (safe)
let eventDispatcher = bridge?.eventDispatcher() as? RCTEventDispatcher
RCTVideo(eventDispatcher: eventDispatcher)
```
  This is safe because _eventDispatcher in RCTVideo is dead code - it is assigned in init and
  cleared in removeFromSuperview, but never actually used. All events are dispatched through
  RCTDirectEventBlock callbacks (onVideoLoad, onVideoProgress, onVideoEnd, etc.) which the interop
  layer sets automatically as props.

  Compatibility

  - Old architecture: self.bridge is the real RCTBridge, eventDispatcher() works as before
  - New architecture (bridgeless): self.bridge is a RCTBridgeProxy