### PR TITLE
fix(ios): stabilize NowPlaying controls

### DIFF
--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -24,9 +24,12 @@ class NowPlayingInfoCenterManager {
   var receivingRemoteControlEvents = false {
     didSet {
       if receivingRemoteControlEvents {
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
           VideoManager.shared.setRemoteControlEventsActive(true)
           UIApplication.shared.beginReceivingRemoteControlEvents()
+          if self?.currentPlayer?.currentItem != nil {
+            self?.updateNowPlayingInfo()
+          }
         }
       } else {
         DispatchQueue.main.async {
@@ -317,10 +320,11 @@ class NowPlayingInfoCenterManager {
 
   // We will observe players rate to find last active player that info will be displayed
   private func observePlayers(player: AVPlayer) -> NSKeyValueObservation {
-    return player.observe(\.rate) { [weak self] player, change in
+    return player.observe(\.rate) { [weak self] player, _ in
       guard let self else { return }
 
-      let rate = change.newValue
+      // Read rate directly from player to avoid nil from missing .new option
+      let rate = player.rate
 
       // case where there is new player that is not paused
       // In this case event is triggered by non currentPlayer

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -323,7 +323,6 @@ class NowPlayingInfoCenterManager {
     return player.observe(\.rate) { [weak self] player, _ in
       guard let self else { return }
 
-      // Read rate directly from player to avoid nil from missing .new option
       let rate = player.rate
 
       // case where there is new player that is not paused

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
@@ -176,8 +176,9 @@ extension HybridVideoPlayer: VideoPlayerObserverDelegate {
   }
 
   func onPlayerItemChange(player: AVPlayer, playerItem: AVPlayerItem?) {
-    if showNotificationControls {
-      NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
+    guard showNotificationControls, let playerItem else { return }
+    DispatchQueue.main.async {
+      NowPlayingInfoCenterManager.shared.updateStaticInfo(ifCurrentItem: playerItem)
     }
   }
 

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
@@ -175,6 +175,12 @@ extension HybridVideoPlayer: VideoPlayerObserverDelegate {
     )
   }
 
+  func onPlayerItemChange(player: AVPlayer, playerItem: AVPlayerItem?) {
+    if showNotificationControls {
+      NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
+    }
+  }
+
   func onPlayerItemWillChange(hasNewPlayerItem: Bool) {
     if hasNewPlayerItem {
       // Set initial buffering state when playerItem is assigned

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
@@ -175,7 +175,7 @@ extension HybridVideoPlayer: VideoPlayerObserverDelegate {
     )
   }
 
-  func onPlayerItemChange(player: AVPlayer, playerItem: AVPlayerItem?) {
+  func onPlayerItemChange(player _: AVPlayer, playerItem: AVPlayerItem?) {
     guard showNotificationControls, let playerItem else { return }
     DispatchQueue.main.async {
       NowPlayingInfoCenterManager.shared.updateStaticInfo(ifCurrentItem: playerItem)

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -342,7 +342,6 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
             try await self.initializePlayerItem()
           }
           self.player.replaceCurrentItem(with: self.playerItem)
-          NowPlayingInfoCenterManager.shared.updateNowPlayingInfo()
           promise.resolve(withResult: ())
         } catch {
           if error is CancellationError {


### PR DESCRIPTION
Closes #4853 

Three fixes for notification controls reliability:

  - KVO rate observer — change.newValue was nil (missing .new option), causing
  findNewCurrentPlayer() to never fire when the current player paused. Fixed by reading player.rate
   directly. This resolves notification controls not switching when one of two playing players is
  paused.
  - onPlayerItemChange delegate — updateNowPlayingInfo() is now called reactively when
  player.currentItem changes, fixing a race condition where showNotificationControls was set before
   replaceCurrentItem was called (e.g. in useVideoPlayer callback).
  - beginReceivingRemoteControlEvents race condition — updateNowPlayingInfo() is re-applied after
  beginReceivingRemoteControlEvents() executes on the main queue, fixing cases where nowPlayingInfo
   was set before iOS started listening.