### PR TITLE
fix: video in fullscreen freeze after swiping

### DIFF
--- a/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
+++ b/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
@@ -136,8 +136,8 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
       guard let self = self else { return }
         
       if context.isCancelled {
-        // iOS bug: window.userInteractionEnabled is left as false after cancelled fullscreen dismiss
-        if let window = playerViewController.view.window, !window.isUserInteractionEnabled {
+        // iOS bug: window.isUserInteractionEnabled is left as false after cancelled fullscreen dismiss
+        if let window = self.playerViewController?.view.window, !window.isUserInteractionEnabled {
           window.isUserInteractionEnabled = true
         }
 
@@ -160,8 +160,8 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
       guard let self = self else { return }
 
       if context.isCancelled {
-        // iOS bug: window.userInteractionEnabled is left as false after cancelled fullscreen transition
-        if let window = playerViewController.view.window, !window.isUserInteractionEnabled {
+        // iOS bug: window.isUserInteractionEnabled is left as false after cancelled fullscreen transition
+        if let window = self.playerViewController?.view.window, !window.isUserInteractionEnabled {
           window.isUserInteractionEnabled = true
         }
 

--- a/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
+++ b/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
@@ -136,6 +136,11 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
       guard let self = self else { return }
         
       if context.isCancelled {
+        // iOS bug: window.userInteractionEnabled is left as false after cancelled fullscreen dismiss
+        if let window = playerViewController.view.window, !window.isUserInteractionEnabled {
+          window.isUserInteractionEnabled = true
+        }
+
         self.delegate?.willEnterFullscreen()
 
         return
@@ -155,6 +160,11 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
       guard let self = self else { return }
 
       if context.isCancelled {
+        // iOS bug: window.userInteractionEnabled is left as false after cancelled fullscreen transition
+        if let window = playerViewController.view.window, !window.isUserInteractionEnabled {
+          window.isUserInteractionEnabled = true
+        }
+
         self.delegate?.willExitFullscreen()
 
         return


### PR DESCRIPTION
Closes #4832 

This pull request addresses an iOS-specific bug in the video component where the `userInteractionEnabled` property of the window can be left as `false` after a cancelled fullscreen transition, preventing user interaction with the app. The fix ensures that user interaction is always re-enabled in these scenarios.

Bug fix for fullscreen transitions:

* In `VideoComponentViewObserver.swift`, added logic to check if `window.isUserInteractionEnabled` is `false` after a cancelled fullscreen enter or exit, and reset it to `true` to restore user interaction