### PR TITLE
fix(ios): add thread-safety to HybridVideoPlayerEventEmitter listeners

### DIFF
--- a/packages/react-native-video/ios/hybrids/VideoPlayerEmitter/HybridVideoPlayerEventEmitter.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayerEmitter/HybridVideoPlayerEventEmitter.swift
@@ -15,20 +15,30 @@ struct ListenerPair {
 }
 
 class HybridVideoPlayerEventEmitter: HybridVideoPlayerEventEmitterSpec {
-  var listeners: [ListenerPair] = []
+  private let listenersLock = NSLock()
+  private var _listeners: [ListenerPair] = []
 
   // MARK: - Private helpers
 
   private func addListener<T>(eventName: String, listener: T) -> ListenerSubscription {
     let id = UUID()
-    listeners.append(ListenerPair(id: id, eventName: eventName, callback: listener))
+    listenersLock.lock()
+    _listeners.append(ListenerPair(id: id, eventName: eventName, callback: listener))
+    listenersLock.unlock()
     return ListenerSubscription(remove: { [weak self] in
-      self?.listeners.removeAll { $0.id == id }
+      guard let self else { return }
+      self.listenersLock.lock()
+      self._listeners.removeAll { $0.id == id }
+      self.listenersLock.unlock()
     })
   }
 
   private func emitEvent<T>(eventName: String, invoke: (T) throws -> Void) {
-    for pair in listeners where pair.eventName == eventName {
+    listenersLock.lock()
+    let snapshot = _listeners
+    listenersLock.unlock()
+
+    for pair in snapshot where pair.eventName == eventName {
       if let callback = pair.callback as? T {
         do {
           try invoke(callback)
@@ -120,7 +130,9 @@ class HybridVideoPlayerEventEmitter: HybridVideoPlayerEventEmitterSpec {
   }
 
   func clearAllListeners() throws {
-    listeners.removeAll()
+    listenersLock.lock()
+    _listeners.removeAll()
+    listenersLock.unlock()
   }
 
   // MARK: - Event emission methods


### PR DESCRIPTION
## Summary

`HybridVideoPlayerEventEmitter.listeners` is accessed from multiple threads without synchronization:

- **Event emission** (`emitEvent`) happens from Swift concurrency async contexts — e.g. `SourceLoaderActor.load()` → `HybridVideoPlayer.initializePlayerItem()` → `onLoadStart()` runs on a cooperative thread pool queue.
- **Listener add/remove** happens from the JS thread via `addListener` / subscription `remove` closures.

This causes **EXC_BAD_ACCESS (SIGSEGV)** crashes in `_swift_release_dealloc` when the array is mutated during iteration, as Swift's copy-on-write optimization leaves a dangling buffer pointer.

### Crash stack (abbreviated)

```
Thread 4 (crashed):
  libswiftCore.dylib  _swift_release_dealloc
  ReactNativeVideo    HybridVideoPlayerEventEmitter.emitEvent<τ_0_0>(…)
  ReactNativeVideo    HybridVideoPlayerEventEmitter.onLoadStart(…)
  ReactNativeVideo    HybridVideoPlayer.initializePlayerItem(…)
  ReactNativeVideo    closure #1 in HybridVideoPlayer.loadSource(…)
```

### Fix

- Protect all reads/writes to the listeners array with an `NSLock`
- Snapshot the array before iterating in `emitEvent` so callbacks execute outside the lock (avoids deadlocks, keeps the critical section minimal)
- Make the backing store `private` to prevent unprotected external access

### Test plan

- [x] Reproduced the crash in a production app with rapid video source changes
- [x] Applied the fix via `patch-package` — crash no longer reproduces
- [x] Verified event delivery still works correctly (onLoadStart, onLoad, onProgress, onEnd all fire)
