### PR TITLE
fix: web events values

### DIFF
--- a/packages/react-native-video/src/core/VideoPlayer.web.ts
+++ b/packages/react-native-video/src/core/VideoPlayer.web.ts
@@ -20,7 +20,9 @@ import type { VideoStore } from './web/VideoStore';
 
 function setExternalSubtitles(
   video: HTMLVideoElement,
-  subtitles: Array<{ uri: string; language?: string; label: string }> | undefined
+  subtitles:
+    | Array<{ uri: string; language?: string; label: string }>
+    | undefined
 ) {
   video.querySelectorAll('track').forEach((t) => t.remove());
   for (const sub of subtitles ?? []) {

--- a/packages/react-native-video/src/core/video-view/useViewEvents.web.ts
+++ b/packages/react-native-video/src/core/video-view/useViewEvents.web.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useInsertionEffect, useRef } from 'react';
 import type { VideoPlayer } from '../VideoPlayer.web';
 import type { VideoViewEvents } from '../types/Events';
 import type { ListenerSubscription } from '../types/EventEmitter';
@@ -46,6 +46,10 @@ export function useViewEvents(
   props: Partial<VideoViewEvents>
 ) {
   const emitter = player.__getEmitter();
+  const callbacksRef = useRef(props);
+  useInsertionEffect(() => {
+    callbacksRef.current = props;
+  });
 
   useEffect(() => {
     const unbindDOM = bindViewDOMEvents(
@@ -55,27 +59,19 @@ export function useViewEvents(
     );
 
     const subs: ListenerSubscription[] = [];
-    for (const [event, callback] of Object.entries(props)) {
-      if (callback) {
-        subs.push(emitter.__addListener(event, callback));
-      }
+    for (const event of Object.keys(callbacksRef.current)) {
+      subs.push(
+        emitter.__addListener(event, (...args: unknown[]) => {
+          callbacksRef.current[event as keyof VideoViewEvents]?.(...args);
+        })
+      );
     }
 
     return () => {
       unbindDOM();
       subs.forEach((sub) => sub.remove());
     };
-  }, [
-    player,
-    emitter,
-    containerRef,
-    props.onFullscreenChange,
-    props.onPictureInPictureChange,
-    props.willEnterFullscreen,
-    props.willExitFullscreen,
-    props.willEnterPictureInPicture,
-    props.willExitPictureInPicture,
-  ]);
+  }, [player, emitter, containerRef]);
 }
 
 export function addViewEventListener<Event extends keyof VideoViewEvents>(

--- a/packages/react-native-video/src/core/web/WebEventEmitter.ts
+++ b/packages/react-native-video/src/core/web/WebEventEmitter.ts
@@ -13,7 +13,6 @@ import {
 export class WebEventEmitter {
   private _listeners: Map<string, Set<(...args: any[]) => void>> = new Map();
   private _cleanup: (() => void) | null = null;
-  private _isBuffering = false;
 
   constructor(private _media: WebMediaProxy) {
     this._bindDOMEvents();
@@ -66,15 +65,7 @@ export class WebEventEmitter {
     const emit = this._emit.bind(this);
 
     const cleanups = [
-      ...attachPlaybackListeners(
-        video,
-        media,
-        emit,
-        () => this._isBuffering,
-        (v) => {
-          this._isBuffering = v;
-        }
-      ),
+      ...attachPlaybackListeners(video, media, emit),
       ...attachMediaInfoListeners(video, media, emit),
       ...attachTrackListeners(video, emit),
     ];

--- a/packages/react-native-video/src/core/web/webDOMEvents.ts
+++ b/packages/react-native-video/src/core/web/webDOMEvents.ts
@@ -15,36 +15,36 @@ function on(target: EventTarget, event: string, handler: () => void): Cleanup {
 export function attachPlaybackListeners(
   video: HTMLVideoElement,
   media: WebMediaProxy,
-  emit: Emit,
-  getIsBuffering: () => boolean,
-  setIsBuffering: (v: boolean) => void
+  emit: Emit
 ): Cleanup[] {
+  // Read directly from video element — store may not have synced yet
+  // when the DOM event fires, causing a stale (previous) value.
+  const isBuffering = () => video.readyState < video.HAVE_FUTURE_DATA;
+
   return [
     on(video, 'play', () => {
       emit('onPlaybackStateChange', {
-        isPlaying: !media.paused,
-        isBuffering: getIsBuffering(),
+        isPlaying: !video.paused,
+        isBuffering: isBuffering(),
       });
     }),
     on(video, 'pause', () => {
       emit('onPlaybackStateChange', {
-        isPlaying: !media.paused,
-        isBuffering: getIsBuffering(),
+        isPlaying: !video.paused,
+        isBuffering: isBuffering(),
       });
     }),
     on(video, 'waiting', () => {
-      setIsBuffering(true);
       emit('onBuffer', true);
       emit('onStatusChange', 'loading');
     }),
     on(video, 'canplay', () => {
-      setIsBuffering(false);
       emit('onBuffer', false);
       emit('onStatusChange', 'readyToPlay');
     }),
     on(video, 'timeupdate', () => {
       emit('onProgress', {
-        currentTime: media.currentTime,
+        currentTime: video.currentTime,
         bufferDuration: media.bufferAhead,
       });
     }),
@@ -58,7 +58,7 @@ export function attachPlaybackListeners(
       emit('onPlaybackRateChange', video.playbackRate);
     }),
     on(video, 'seeked', () => {
-      emit('onSeek', media.currentTime);
+      emit('onSeek', video.currentTime);
     }),
   ];
 }
@@ -72,10 +72,10 @@ export function attachMediaInfoListeners(
 ): Cleanup[] {
   return [
     on(video, 'durationchange', () => {
-      if (media.duration > 0) {
+      if (video.duration > 0) {
         emit('onLoad', {
-          currentTime: media.currentTime,
-          duration: media.duration,
+          currentTime: video.currentTime,
+          duration: video.duration,
           width: video.videoWidth,
           height: video.videoHeight,
           orientation: 'unknown',
@@ -107,10 +107,12 @@ export function attachMediaInfoListeners(
     on(video, 'loadeddata', () => {
       emit('onReadyToDisplay');
     }),
+    // Read directly from video element — store may not have synced yet
+    // when the DOM event fires, causing a stale (previous) value.
     on(video, 'volumechange', () => {
       emit('onVolumeChange', {
-        volume: media.volume,
-        muted: media.muted,
+        volume: video.volume,
+        muted: video.muted,
       });
     }),
     on(video, 'error', () => {


### PR DESCRIPTION
This pull request refactors the web event handling in the React Native Video package to improve reliability and maintainability. The main improvements include reading playback and media information directly from the video DOM element instead of relying on potentially stale values from the media store, simplifying the buffering logic, and updating the event subscription mechanism to ensure the latest props are always used.

**Event Handling and Propagation Improvements:**

* Playback and media info events now read directly from the `HTMLVideoElement` instead of the `WebMediaProxy` store, ensuring up-to-date values when DOM events fire. This affects properties like `currentTime`, `duration`, `volume`, `muted`, and buffering state

* The buffering logic has been simplified by removing the `_isBuffering` state from `WebEventEmitter` and instead checking the video element's `readyState` directly within event listeners

**React Hook and Subscription Updates:**

* The `useViewEvents.web.ts` hook now uses a `useRef` and `useInsertionEffect` to always reference the latest props when subscribing to events, preventing stale closures and ensuring event handlers are always up-to-date

**Minor Code Quality Improvements:**

* Formatting and type improvements for subtitles handling in `VideoPlayer.web.ts`.