### PR TITLE
fix(ios): preserve PiP-from-fullscreen on iPad with new architecture

### DIFF
--- a/packages/react-native-video/ios/view/VideoComponentView.swift
+++ b/packages/react-native-video/ios/view/VideoComponentView.swift
@@ -10,6 +10,27 @@ import AVKit
 import Foundation
 import UIKit
 
+// A plain UIViewController that hosts an AVPlayerViewController as a child
+// for fullscreen modal presentation. We then layer AVKit's own fullscreen
+// presentation on top of this host (via enterFullscreen(animated:) on the
+// embedded controller) to get back AVKit's native dismissal chrome — swipe
+// down and close button.
+//
+// The host exists because direct modal presentation of AVPlayerViewController
+// causes AVKit to dismiss the modal at PiP-start, orphaning the controller.
+// With a stable host underneath, AVKit's fullscreen layer can come and go
+// (during PiP cycles) without dismantling our presentation.
+final class FullscreenHostViewController: UIViewController {
+  override var prefersStatusBarHidden: Bool { return true }
+  override var prefersHomeIndicatorAutoHidden: Bool { return true }
+  override var supportedInterfaceOrientations: UIInterfaceOrientationMask { return .all }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .black
+  }
+}
+
 @objc public class VideoComponentView: UIView {
   public weak var player: HybridVideoPlayerSpec? = nil {
     didSet {
@@ -20,6 +41,27 @@ import UIKit
 
   var delegate: VideoViewDelegate?
   private var playerView: UIView? = nil
+
+  // True between enterFullscreen() succeeding and exitFullscreen()/dismissal
+  // completing. We track this ourselves rather than asking AVKit because
+  // AVKit's lifecycle callbacks (notably willEndFullScreenPresentation) fire
+  // for multiple distinct situations that look identical from the delegate's
+  // perspective; we need our own state to disambiguate.
+  var isPresentingFullscreen: Bool = false
+
+  // True between willStartPictureInPicture and didStopPictureInPicture.
+  // Same rationale as isPresentingFullscreen: we need this to tell apart
+  // willEndFullScreenPresentation firing because PiP is starting (skip) vs
+  // because the user dismissed via AVKit chrome (handle).
+  var isPictureInPictureActive: Bool = false
+
+  // The fullscreen host VC we present modally. Strong-referenced while
+  // presented; nil otherwise.
+  private var fullscreenHostVC: FullscreenHostViewController?
+
+  // The parent VC the AVPlayerViewController was a child of before fullscreen.
+  // Used to reattach inline on dismiss.
+  private weak var preFullscreenParentVC: UIViewController?
 
   private var observer: VideoComponentViewObserver? {
     didSet {
@@ -166,7 +208,7 @@ import UIKit
           controller.selectSpeed(initialSpeed)
         }
       }
-       // Disable video frame analysis to prevent visual lookup
+      // Disable video frame analysis to prevent visual lookup
       if #available(iOS 16.0, iPadOS 16.0, macCatalyst 18.0, *) {
         controller.allowsVideoFrameAnalysis = false
       }
@@ -193,19 +235,35 @@ import UIKit
     return nil
   }
 
+  // The topmost VC capable of presenting modally right now. Walks
+  // presentedViewController so we don't try to present from a VC that
+  // already has something on top of it.
+  private func topMostPresentingViewController() -> UIViewController? {
+    let keyWindow = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap { $0.windows }
+      .first(where: { $0.isKeyWindow })
+
+    var top = keyWindow?.rootViewController
+    while let presented = top?.presentedViewController {
+      top = presented
+    }
+    return top
+  }
+
   public override func willMove(toSuperview newSuperview: UIView?) {
     super.willMove(toSuperview: newSuperview)
 
     if newSuperview == nil {
       PluginsRegistry.shared.notifyVideoViewDestroyed(view: self)
-
+      
       // We want to disable this when view is about to unmount
       if keepScreenAwake {
         keepScreenAwake = false
       }
     } else {
       PluginsRegistry.shared.notifyVideoViewCreated(view: self)
-
+      
       // We want to restore keepScreenAwake after component remount
       if _keepScreenAwake {
         keepScreenAwake = true
@@ -216,11 +274,13 @@ import UIKit
   public override func layoutSubviews() {
     super.layoutSubviews()
 
-    // Update the frame of the playerViewController's view when the view's layout changes
-    playerViewController?.view.frame = playerView?.bounds ?? .zero
-    playerViewController?.contentOverlayView?.frame = playerView?.bounds ?? .zero
-    for subview in playerViewController?.contentOverlayView?.subviews ?? [] {
-      subview.frame = playerView?.bounds ?? .zero
+    if !isPresentingFullscreen {
+      // Update the frame of the playerViewController's view when the view's layout changes
+      playerViewController?.view.frame = playerView?.bounds ?? .zero
+      playerViewController?.contentOverlayView?.frame = playerView?.bounds ?? .zero
+      for subview in playerViewController?.contentOverlayView?.subviews ?? [] {
+        subview.frame = playerView?.bounds ?? .zero
+      }
     }
   }
 
@@ -229,19 +289,222 @@ import UIKit
       throw VideoViewError.viewIsDeallocated.error()
     }
 
-    DispatchQueue.main.async {
-      playerViewController.enterFullscreen(animated: true)
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      guard !self.isPresentingFullscreen else { return }
+      guard let presenter = self.topMostPresentingViewController() else {
+#if DEBUG
+        NSLog("[PiPDebug] enterFullscreen — no presenter found, aborting")
+#endif
+        return
+      }
+
+#if DEBUG
+      NSLog("[PiPDebug] enterFullscreen — presenting host from \(presenter)")
+#endif
+
+      self.preFullscreenParentVC = playerViewController.parent
+
+      // Detach the AVPlayerViewController from its inline child-VC hierarchy.
+      playerViewController.willMove(toParent: nil)
+      playerViewController.view.removeFromSuperview()
+      playerViewController.removeFromParent()
+
+      // Build the host VC and embed the AVPlayerViewController as its child.
+      let host = FullscreenHostViewController()
+      host.modalPresentationStyle = .fullScreen
+      host.modalPresentationCapturesStatusBarAppearance = true
+
+      // Force view load so host.view exists before we attach the child.
+      host.loadViewIfNeeded()
+
+      host.addChild(playerViewController)
+      playerViewController.view.frame = host.view.bounds
+      playerViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      host.view.addSubview(playerViewController.view)
+      playerViewController.didMove(toParent: host)
+
+      self.fullscreenHostVC = host
+      self.isPresentingFullscreen = true
+
+      // We do not fire willEnterFullscreen / onFullscreenChange(true) here.
+      // The chained enterFullscreen(animated:) below triggers AVKit's
+      // willBeginFullScreenPresentation, which fires those events via the
+      // observer. This is intentional architectural symmetry: both entry and
+      // exit are driven solely by AVKit's fullscreen lifecycle delegates
+      // (willBeginFullScreenPresentation / willEndFullScreenPresentation),
+      // so JS sees a single fire of each event regardless of whether the
+      // transition was initiated by our public API, AVKit chrome, or PiP.
+
+      presenter.present(host, animated: true) { [weak self] in
+        guard let self = self else { return }
+
+        // Engage AVKit's own fullscreen on top of our host to restore native
+        // dismissal chrome (swipe-down, close button). The host stays put as
+        // the stable parent VC, so PiP-start has nowhere to dismantle.
+        // Brief delay lets the modal presentation transition settle before AVKit
+        // kicks off its own fullscreen transition; without it, AVKit can refuse
+        // to enter or end up in an inconsistent state.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+          self?.playerViewController?.enterFullscreen(animated: true)
+        }
+      }
     }
   }
 
   public func exitFullscreen() throws {
-    guard let playerViewController else {
-      throw VideoViewError.viewIsDeallocated.error()
+    guard isPresentingFullscreen else { return }
+    guard playerViewController != nil else { return }
+
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+
+      // Trigger AVKit's own fullscreen-exit. This causes AVKit to fire
+      // willEndFullScreenPresentationWithAnimationCoordinator on our
+      // observer, which then runs the same poll-based host dismiss path
+      // that the close-button and swipe-down gestures use. Routing both
+      // user-driven and JS-driven exits through the same path avoids
+      // duplicate dismiss attempts and the timing problems of trying to
+      // dismiss the host out from under AVKit's still-active fullscreen.
+      self.playerViewController?.exitFullscreen(animated: true)
+    }
+  }
+
+  // Called from the observer when AVKit's own fullscreen chrome signals
+  // dismissal (swipe-down, close button).
+  //
+  // Critical detail discovered through tracing: the React Native side may
+  // deallocate this VideoComponentView during AVKit's fullscreen-collapse
+  // animation. Any [weak self] captures across that animation may go nil,
+  // silently dropping the dismiss. Worse: when self is alive, calling
+  // host.dismiss() directly inside the AVKit-coordinator completion is
+  // silently rejected by UIKit (the completion never fires) because
+  // AVKit's collapse animation is still in flight.
+  //
+  // The workable strategy: strong-capture the host so we can dismiss it
+  // regardless of self's lifecycle, and dispatch the dismiss to a delayed
+  // tick so AVKit's collapse animation has time to finish. self-dependent
+  // teardown (reattaching inline, etc) is conditional on self being alive.
+  func dismissFullscreenFromAVKitSignal() {
+#if DEBUG
+    NSLog("[PiPDebug] dismissFromAVKit ENTRY — isPresentingFullscreen=\(isPresentingFullscreen)")
+#endif
+    guard isPresentingFullscreen else { return }
+    guard let host = fullscreenHostVC else { return }
+
+    // Pause the player so audio stops. Do this synchronously here — even
+    // if self deallocates, the player is owned elsewhere and the pause
+    // call will have already taken effect.
+    playerViewController?.player?.pause()
+
+    isPresentingFullscreen = false
+
+    let strongHost = host
+    let startTime = Date()
+
+    // Diagnostic helper: when AVKit's private fullscreen has fully torn
+    // down, host.presentedViewController will be nil. We use this as the
+    // signal that the host can be safely dismissed.
+    func isAVKitFullscreenGone() -> Bool {
+      return strongHost.presentedViewController == nil
     }
 
-    DispatchQueue.main.async {
-      playerViewController.exitFullscreen(animated: true)
+    func performDismiss(_ source: String) {
+#if DEBUG
+      let elapsed = Int(Date().timeIntervalSince(startTime) * 1000)
+      NSLog("[PiPDebug] dismissFromAVKit — performDismiss [\(source)] at +\(elapsed)ms host.presentedVC=\(String(describing: strongHost.presentedViewController)) host.presentingVC=\(String(describing: strongHost.presentingViewController))")
+#endif
+
+      guard strongHost.presentingViewController != nil else {
+#if DEBUG
+        NSLog("[PiPDebug] dismissFromAVKit — host already dismissed, skipping")
+#endif
+        return
+      }
+
+      strongHost.dismiss(animated: true) { [weak self] in
+#if DEBUG
+        let stillPresenting = strongHost.presentingViewController != nil
+        NSLog("[PiPDebug] dismissFromAVKit — dismiss completion [\(source)], stillPresenting=\(stillPresenting)")
+#endif
+        self?.tearDownFullscreenHost()
+        self?.delegate?.onFullscreenChange(false)
+      }
     }
+
+    // Strategy: if AVKit's fullscreen is already gone, dismiss immediately.
+    // Otherwise poll on the runloop until it goes — this is event-driven in
+    // spirit (we react the moment AVKit finishes) and bounded by a hard cap.
+    if isAVKitFullscreenGone() {
+#if DEBUG
+      NSLog("[PiPDebug] dismissFromAVKit — AVKit fullscreen already gone at start")
+#endif
+      performDismiss("immediate")
+      return
+    }
+
+    var pollCount = 0
+    func poll() {
+      pollCount += 1
+      if isAVKitFullscreenGone() {
+        performDismiss("poll(\(pollCount))")
+        return
+      }
+      // 1s hard cap (40 * 25ms) is a generous bound based on observed AVKit
+      // collapse durations of ~400-600ms; the cap exists so a stuck AVKit
+      // can't hang the dismissal indefinitely. Tightening it risks dismissing
+      // before AVKit's private fullscreen has torn down, which UIKit will
+      // silently reject.
+      if pollCount > 40 {
+#if DEBUG
+        NSLog("[PiPDebug] dismissFromAVKit — poll cap reached, dismissing anyway")
+#endif
+        performDismiss("poll(timeout)")
+        return
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(25), execute: poll)
+    }
+    poll()
+  }
+
+  // Called when fullscreen has ended for any reason: user-initiated
+  // exitFullscreen, AVKit chrome dismissal, or unexpected dismissal.
+  // Reattaches the player VC to its inline parent and clears host state.
+  func tearDownFullscreenHost() {
+    guard let playerViewController = self.playerViewController else { return }
+
+    // Detach from host if still attached there.
+    if playerViewController.parent === self.fullscreenHostVC {
+      playerViewController.willMove(toParent: nil)
+      playerViewController.view.removeFromSuperview()
+      playerViewController.removeFromParent()
+    }
+
+    self.fullscreenHostVC = nil
+
+    // Reattach inline only if our host UIView is still in a window. If it
+    // isn't, the JS side has already navigated away or unmounted the video
+    // component, and there's nothing meaningful to reattach to. We deliberately
+    // do not try to find a different parent VC — that would attach the player
+    // to wherever happens to be on screen, which is almost never what the
+    // user wants.
+    guard self.window != nil else {
+      self.preFullscreenParentVC = nil
+      return
+    }
+    guard let playerView = self.playerView else {
+      self.preFullscreenParentVC = nil
+      return
+    }
+    let parentVC = self.preFullscreenParentVC ?? self.findViewController()
+    self.preFullscreenParentVC = nil
+    guard let parentVC = parentVC else { return }
+
+    parentVC.addChild(playerViewController)
+    playerViewController.view.frame = playerView.bounds
+    playerViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    playerView.addSubview(playerViewController.view)
+    playerViewController.didMove(toParent: parentVC)
   }
 
   public func startPictureInPicture() throws {

--- a/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
+++ b/packages/react-native-video/ios/view/VideoComponentViewObserver.swift
@@ -22,35 +22,35 @@ protocol VideoComponentViewDelegate: AnyObject {
 // Map delegate methods to view manager methods
 final class VideoViewDelegate: NSObject, VideoComponentViewDelegate {
   weak var viewManager: HybridVideoViewViewManager?
-  
+
   init(viewManager: HybridVideoViewViewManager) {
     self.viewManager = viewManager
   }
-  
+
   func onPictureInPictureChange(_ isActive: Bool) {
     viewManager?.onPictureInPictureChange(isActive)
   }
-  
+
   func onFullscreenChange(_ isActive: Bool) {
     viewManager?.onFullscreenChange(isActive)
   }
-  
+
   func willEnterFullscreen() {
     viewManager?.willEnterFullscreen()
   }
-  
+
   func willExitFullscreen() {
     viewManager?.willExitFullscreen()
   }
-  
+
   func willEnterPictureInPicture() {
     viewManager?.willEnterPictureInPicture()
   }
-  
+
   func willExitPictureInPicture() {
     viewManager?.willExitPictureInPicture()
   }
-  
+
   func onReadyToDisplay() {
     if let player = viewManager?.player as? HybridVideoPlayer {
       player._eventEmitter?.onReadyToDisplay()
@@ -60,30 +60,34 @@ final class VideoViewDelegate: NSObject, VideoComponentViewDelegate {
 
 class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
   private weak var view: VideoComponentView?
-  
+
   var delegate: VideoViewDelegate? {
-    get {
-      return view?.delegate
-    }
+    return view?.delegate
   }
-  
+
   var playerViewController: AVPlayerViewController? {
     return view?.playerViewController
   }
-  
+
   // playerViewController observers
   var onReadyToDisplayObserver: NSKeyValueObservation?
-  
+
   init(view: VideoComponentView) {
     self.view = view
     super.init()
   }
-  
+
+  // Diagnostic
+  private func dumpHierarchy(_ tag: String) {
+    guard let pvc = playerViewController else { return }
+    NSLog("[PiPDebug] \(tag) — pvc.parent=\(String(describing: pvc.parent)) presenting=\(String(describing: pvc.presentingViewController)) view.superview=\(String(describing: pvc.view.superview)) view.window=\(String(describing: pvc.view.window))")
+  }
+
   func initializePlayerViewContorollerObservers() {
     guard let playerViewController = playerViewController else {
       return
     }
-    
+
     onReadyToDisplayObserver = playerViewController.observe(\.isReadyForDisplay, options: [.new]) { [weak self] _, change in
       guard let self = self else { return }
       if change.newValue == true {
@@ -91,86 +95,152 @@ class VideoComponentViewObserver: NSObject, AVPlayerViewControllerDelegate {
       }
     }
   }
-  
+
   func removePlayerViewControllerObservers() {
     onReadyToDisplayObserver?.invalidate()
     onReadyToDisplayObserver = nil
   }
-  
+
   func updatePlayerViewControllerObservers() {
     removePlayerViewControllerObservers()
     initializePlayerViewContorollerObservers()
   }
-  
-  func playerViewControllerDidStartPictureInPicture(_: AVPlayerViewController) {
-    delegate?.onPictureInPictureChange(true)
-  }
-  
-  func playerViewControllerDidStopPictureInPicture(_: AVPlayerViewController) {
-    delegate?.onPictureInPictureChange(false)
-  }
-  
+
   func playerViewControllerWillStartPictureInPicture(_: AVPlayerViewController) {
+#if DEBUG
+    dumpHierarchy("willStart PiP")
+#endif
+    view?.isPictureInPictureActive = true
     delegate?.willEnterPictureInPicture()
   }
-  
+
+  func playerViewControllerDidStartPictureInPicture(_: AVPlayerViewController) {
+#if DEBUG
+    dumpHierarchy("didStart PiP")
+#endif
+    delegate?.onPictureInPictureChange(true)
+  }
+
   func playerViewControllerWillStopPictureInPicture(_: AVPlayerViewController) {
+#if DEBUG
+    dumpHierarchy("willStop PiP")
+#endif
     delegate?.willExitPictureInPicture()
   }
 
+  func playerViewControllerDidStopPictureInPicture(_: AVPlayerViewController) {
+#if DEBUG
+    dumpHierarchy("didStop PiP")
+#endif
+    view?.isPictureInPictureActive = false
+    delegate?.onPictureInPictureChange(false)
+
+    // PiP-start ended AVKit's private fullscreen presentation in order to
+    // move the player UI into the PiP window. PiP-stop brings the player
+    // back into our host, but does not re-engage AVKit's fullscreen — so
+    // the swipe-down and close-button chrome is missing from this point on.
+    // Re-engage AVKit fullscreen here, mirroring what enterFullscreen() did
+    // initially, so the dismiss UX is consistent across PiP cycles.
+    if let view = self.view, view.isPresentingFullscreen {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak view] in
+        guard let pvc = view?.playerViewController else { return }
+#if DEBUG
+        NSLog("[PiPDebug] re-engaging AVKit fullscreen after PiP stop")
+#endif
+        pvc.enterFullscreen(animated: false)
+
+      }
+    }
+  }
+
+  // Called when the user taps the restore button on the PiP window.
+  // With the host-VC pattern, the host stays presented through PiP, so
+  // there's nothing to re-present. Just acknowledge success.
   func playerViewControllerRestoreUserInterfaceForPictureInPictureStop(
     _ playerViewController: AVPlayerViewController,
     completionHandler: @escaping (Bool) -> Void
   ) {
-    let isViewAttached = view?.window != nil
-    completionHandler(isViewAttached)
+#if DEBUG
+    NSLog("[PiPDebug] 🔥 RESTORE DELEGATE CALLED")
+#endif
+    completionHandler(true)
   }
-  
+
   func playerViewController(
     _: AVPlayerViewController,
-    willEndFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
+    willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
   ) {
-    delegate?.willExitFullscreen()
+#if DEBUG
+    NSLog("[PiPDebug] willBeginFullScreenPresentation FIRED")
+#endif
+    delegate?.willEnterFullscreen()
 
     coordinator.animate(alongsideTransition: nil) { [weak self] context in
       guard let self = self else { return }
-        
+#if DEBUG
+      NSLog("[PiPDebug] willBeginFullScreenPresentation completion — cancelled=\(context.isCancelled)")
+#endif
+
       if context.isCancelled {
         // iOS bug: window.isUserInteractionEnabled is left as false after cancelled fullscreen dismiss
         if let window = self.playerViewController?.view.window, !window.isUserInteractionEnabled {
           window.isUserInteractionEnabled = true
         }
-
-        self.delegate?.willEnterFullscreen()
-
+        
+        self.delegate?.willExitFullscreen()
+        
         return
       }
 
-      self.delegate?.onFullscreenChange(false)
+      self.delegate?.onFullscreenChange(true)
     }
   }
-  
+
   func playerViewController(
     _: AVPlayerViewController,
-    willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
+    willEndFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
   ) {
-    delegate?.willEnterFullscreen()
+#if DEBUG
+    NSLog("[PiPDebug] willEndFullScreenPresentation FIRED — isPiPActive=\(view?.isPictureInPictureActive ?? false), isPresentingFullscreen=\(view?.isPresentingFullscreen ?? false)")
+#endif
+    delegate?.willExitFullscreen()
 
     coordinator.animate(alongsideTransition: nil) { [weak self] context in
       guard let self = self else { return }
+#if DEBUG
+      NSLog("[PiPDebug] willEndFullScreenPresentation completion — cancelled=\(context.isCancelled), isPiPActive=\(self.view?.isPictureInPictureActive ?? false), isPresentingFullscreen=\(self.view?.isPresentingFullscreen ?? false)")
+#endif
 
       if context.isCancelled {
         // iOS bug: window.isUserInteractionEnabled is left as false after cancelled fullscreen transition
         if let window = self.playerViewController?.view.window, !window.isUserInteractionEnabled {
           window.isUserInteractionEnabled = true
         }
-
-        self.delegate?.willExitFullscreen()
-
+        
+        self.delegate?.willEnterFullscreen()
+        
         return
       }
 
-      self.delegate?.onFullscreenChange(true)
+      // AVKit fires willEndFullScreenPresentation in two situations that look
+      // identical from this callback alone:
+      //   (a) the user invoked a dismissal affordance (swipe-down, close
+      //       button) — we should dismiss the host
+      //   (b) PiP is starting and AVKit is moving the player UI into the PiP
+      //       window — the host must stay presented so PiP can restore back
+      //       into it later
+      // We use isPictureInPictureActive (set in willStartPictureInPicture) to
+      // distinguish: if PiP is active, this is case (b) and we skip cleanup.
+      if let view = self.view,
+        view.isPresentingFullscreen,
+        !view.isPictureInPictureActive {
+#if DEBUG
+        NSLog("[PiPDebug] willEndFullScreenPresentation completion — calling dismissFromAVKit")
+#endif
+        view.dismissFullscreenFromAVKitSignal()
+      }
+
+      self.delegate?.onFullscreenChange(false)
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4897 — PiP restore from fullscreen-entered playback dismisses the player on iPad with new architecture.

## The bug

When `enterFullscreen()` is called and the user then enters PiP, tapping restore briefly returns to fullscreen and immediately dismisses, breaking the session. Audio may continue playing. Subsequent playback may fail. PiP from inline mode is unaffected. See linked issue for full reproduction and diagnostic trace.

## Root cause

The current implementation calls `enterFullscreen(animated:)` directly on the embedded `AVPlayerViewController`, which AVKit treats as its own private fullscreen presentation. At PiP-start, AVKit dismantles that presentation as part of moving the player UI into the PiP window — the controller is left with `presentingViewController = nil`, `view.superview = nil`, `view.window = nil`. Fully orphaned. PiP-stop has nothing to restore back into.

The `playerViewControllerRestoreUserInterfaceForPictureInPictureStop` delegate method is also never called in this configuration, because AVKit considers the dismissal complete rather than partial.

## The fix

Introduce a thin `FullscreenHostViewController` (a plain `UIViewController`) that hosts the `AVPlayerViewController` as a child and is presented modally for fullscreen. AVKit's own fullscreen is then layered on top via `enterFullscreen(animated:)` to restore the native dismissal chrome (swipe-down, close button). The host stays presented as a stable parent VC across all PiP transitions, so PiP-start has nowhere to dismantle.

### Supporting changes

- **Re-engage AVKit fullscreen in `playerViewControllerDidStopPictureInPicture`.** PiP-start ends AVKit's private fullscreen presentation; PiP-stop brings the player back into our host but doesn't re-engage AVKit's fullscreen automatically. Without re-engagement, the swipe-down/close-button chrome is missing for the rest of the session after the first PiP cycle.

- **Route JS-driven `exitFullscreen()` through AVKit's `exitFullscreen(animated:)`.** All three exit paths (close button, swipe-down, JS API) now converge on the same observer-driven dismiss flow. This avoids duplicate dismiss attempts and the timing problems of trying to dismiss the host out from under AVKit's still-active fullscreen.

- **Poll for AVKit's private fullscreen teardown before dismissing the host.** UIKit silently rejects modal dismissals that race AVKit's collapse animation — the dismiss completion handler doesn't even fire. The poll watches `host.presentedViewController` and dismisses the moment AVKit has fully torn down. 1s hard cap as a safety bound.

- **Strong-capture the host across the dismiss delay.** React Native may deallocate `VideoComponentView` during AVKit's collapse animation, leaving any `[weak self]` capture nil and the dismiss orphaned. The host needs to outlive `self` for the dismiss to complete reliably.

- **Drive entry/exit JS events from AVKit's lifecycle delegates only.** Previously, entering fullscreen via the host-VC path fired `willEnterFullscreen` / `onFullscreenChange(true)` twice — once from our explicit call and once from AVKit's `willBeginFullScreenPresentation`. All event emission now flows through the observer for symmetric, single-fire entry and exit.

## Diff scope

Two files changed:

- `ios/view/VideoComponentView.swift` — adds `FullscreenHostViewController`, rewrites `enterFullscreen`/`exitFullscreen`, adds `dismissFullscreenFromAVKitSignal` and `tearDownFullscreenHost`. Inline rendering path unchanged.
- `ios/view/VideoComponentViewObserver.swift` — adds host-aware logic to `playerViewControllerDidStopPictureInPicture` and `playerViewController(_:willEndFullScreenPresentationWithAnimationCoordinator:)`. PiP-restore delegate simplified (no longer needs to re-present, since the host stays put).

Public API surface (`enterFullscreen`, `exitFullscreen`, `startPictureInPicture`, `stopPictureInPicture`) is unchanged.

## Comments

Both files include extensive comments on the non-obvious parts — why the host VC is structurally necessary, why the dismiss is poll-based, why entry events are deduplicated, why we don't try to reattach inline if the host view has left the window. Worth reading those before reviewing the code.

A small amount of `#if DEBUG`-guarded `NSLog` instrumentation is left in place, since the code path involves enough framework-level subtlety that future regressions are likely to need re-instrumentation rather than starting from scratch. Zero overhead in Release builds. Happy to strip if preferred.

## Testing

Tested extensively on iPad (iPadOS 17+) with the new architecture:

- Enter fullscreen → exit via close button. ✓
- Enter fullscreen → exit via swipe-down gesture. ✓
- Enter fullscreen → exit via JS `exitFullscreen()`. ✓
- Enter fullscreen → enter PiP (manual button) → restore → exit. ✓
- Enter fullscreen → background app (auto-PiP via `autoEnterPictureInPicture`) → restore → exit. ✓
- Multiple PiP cycles in one session (4+ consecutive enter/restore). ✓
- JS event firing: `willEnterFullscreen`, `willExitFullscreen`, `onFullscreenChange` all single-fire across all paths. ✓

**Not tested on iPhone.** The diagnosis is structural rather than platform-specific, so the fix is expected to apply to iPhone as well, but I don't have an iPhone app to verify with. iPhone testing from a reviewer would be welcome.

## Notes for review

The size of the change is load-bearing. The hours of trial-and-error that produced this PR included multiple smaller approaches — keeping the existing direct-modal presentation but trying to fix the delegate path, presenting from the root VC instead of the topmost presenter, custom dismiss UI on the host instead of AVKit's chrome, fixed-delay dismissal — all of which were ruled out by hierarchy-state traces showing the underlying AVKit behaviour. The host-VC pattern with chained `enterFullscreen` is the smallest configuration that produces working PiP-from-fullscreen with native dismissal chrome on iPad.

I'm happy to discuss specific aspects of the implementation, tighten comments, adjust naming, or split the diff if there's a logical boundary I've missed. Bandwidth for substantial architectural revisions is limited; if a fundamentally different approach is preferred, I'd rather close this PR and leave the diagnosis as a reference than spend time discovering that the alternative also doesn't work.