### PR TITLE
fix(windows): clear video source when src is empty

### DIFF
--- a/windows/ReactNativeVideoCPP/ReactVideoView.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoView.cpp
@@ -202,6 +202,14 @@ void ReactVideoView::Set_UriString(hstring const &value) {
   }
 }
 
+void ReactVideoView::Clear_Source() {
+  m_uriString = L"";
+  if (m_player != nullptr) {
+    m_player.Pause();
+    m_player.Source(nullptr);
+  }
+}
+
 void ReactVideoView::Set_Paused(bool value) {
   m_isPaused = value;
   if (m_player != nullptr) {

--- a/windows/ReactNativeVideoCPP/ReactVideoView.h
+++ b/windows/ReactNativeVideoCPP/ReactVideoView.h
@@ -9,6 +9,7 @@ struct ReactVideoView : ReactVideoViewT<ReactVideoView> {
  public:
   ReactVideoView(winrt::Microsoft::ReactNative::IReactContext const &reactContext);
   void Set_UriString(hstring const &value);
+  void Clear_Source();
   void Set_IsLoopingEnabled(bool value);
   void Set_Paused(bool isPaused);
   void Set_Muted(bool isMuted);

--- a/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
@@ -63,12 +63,22 @@ void ReactVideoViewManager::UpdateProperties(
     for (auto const &pair : propertyMap) {
       auto const &propertyName = pair.first;
       auto const &propertyValue = pair.second;
-      if (!propertyValue.IsNull()) {
-        if (propertyName == "src") {
+      if (propertyName == "src") {
+        if (propertyValue.IsNull()) {
+          reactVideoView.Clear_Source();
+        } else {
           auto const &srcMap = propertyValue.AsObject();
-          auto const &uri = srcMap.at("uri");
-          reactVideoView.Set_UriString(to_hstring(uri.AsString()));
-        } else if (propertyName == "resizeMode") {
+          auto const uri = srcMap.find("uri");
+          if (uri == srcMap.end() || uri->second.IsNull() || uri->second.AsString().empty()) {
+            reactVideoView.Clear_Source();
+          } else {
+            reactVideoView.Set_UriString(to_hstring(uri->second.AsString()));
+          }
+        }
+        continue;
+      }
+      if (!propertyValue.IsNull()) {
+        if (propertyName == "resizeMode") {
           auto resizeModeString = propertyValue.AsString();
           Stretch resizeMode = Stretch::None;
           if (resizeModeString == "contain") {


### PR DESCRIPTION
## Summary

Fixes #3188.

### Motivation

On Windows, setting `<Video source={null} />` after a video has already loaded should clear the current source. Instead, the Windows view manager only handled non-null `src` updates, and an empty `uri` could still be passed through to the WinRT `Uri` constructor. That leaves the player in a bad state and can crash when the app is trying to stop playback.

### Changes

- Add a small Windows helper to pause the player and clear its media source
- Treat `src: null`, missing `uri`, and empty `uri` as a clear-source update
- Keep the existing non-empty URI path unchanged

## Test plan

- Checked the Windows prop flow locally against the reported `source={null}` case
- Reviewed the diff to keep the change scoped to Windows source handling

I do not have a Windows dev environment available in this macOS workspace, so I was not able to run the native Windows sample build locally.