### PR TITLE
fix(android): add null check for player in videoLoaded() to prevent NPE

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1483,7 +1483,7 @@ public class ReactExoplayerView extends FrameLayout implements
     }
 
     private void videoLoaded() {
-        if (!player.isPlayingAd() && loadVideoStarted) {
+        if (player != null && !player.isPlayingAd() && loadVideoStarted) {
             loadVideoStarted = false;
             if (audioTrackType != null) {
                 setSelectedAudioTrack(audioTrackType, audioTrackValue);


### PR DESCRIPTION
## Fix Summary
Add null check for  in  method to prevent NullPointerException.

**Bug**: 

**Root cause**: Race condition where ExoPlayer listener posts callback on main looper, before it's dispatched the player is released (nulled), then the callback fires and causes NPE when calling .

**Fix**: Changed:

To:


Fixes #4902