### PR TITLE
fix(types): support ImageRequireSource in ReactVideoSource (#4901)

### DIFF
--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -44,11 +44,13 @@ export type ReactVideoSourceProperties = {
   bufferConfig?: BufferConfig;
 };
 
-export type ReactVideoSource = Readonly<
-  Omit<ReactVideoSourceProperties, 'uri'> & {
-    uri?: string | NodeRequire;
-  }
->;
+export type ReactVideoSource =
+  | ImageRequireSource
+  | Readonly<
+      Omit<ReactVideoSourceProperties, 'uri'> & {
+        uri?: string | ImageRequireSource;
+      }
+    >;
 
 export type ReactVideoPosterSource = ImageURISource | ImageRequireSource;
 


### PR DESCRIPTION
## Fix: TypeScript type bug in ReactVideoSource (#4901)

**Problem:** React Native asset `require()` returns `ImageRequireSource` (a `number`), but `ReactVideoSource` type only accepted `string | NodeRequire`. The runtime code in `Video.tsx` already handles numeric asset ids at both source positions, but the TS type didn't reflect this.

**Fix:** Widen `ReactVideoSource` to also accept `ImageRequireSource` directly, matching the documented runtime behavior and the README example.

```ts
// Before
export type ReactVideoSource = Readonly<
  Omit<ReactVideoSourceProperties, 'uri'> & {
    uri?: string | NodeRequire;
  }
>;

// After  
export type ReactVideoSource =
  | ImageRequireSource
  | Readonly<
      Omit<ReactVideoSourceProperties, 'uri'> & {
        uri?: string | ImageRequireSource;
      }
    >;
```

**Changed file:** `src/types/video.ts` (support/6.x.x branch)

**Testing:** This is a pure type-only change. The runtime behavior is already correct (the code in `Video.tsx` already handles `typeof _source === 'number'` and `typeof _source.uri === 'number'`).

Fixes #4901