### PR TITLE
fix(android): preserve resize mode when recreating PlayerView

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/view/VideoView.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/view/VideoView.kt
@@ -182,6 +182,8 @@ class VideoView @JvmOverloads constructor(
       setShowSubtitleButton(true)
       useController = false
 
+      resizeMode = this@VideoView.resizeMode.toAspectRatioFrameLayout()
+
       // Apply optimizations based on video player size if needed
       configureForSmallPlayer()
     }


### PR DESCRIPTION
## Summary
- Reapply the current resize mode to newly created Android `PlayerView` instances.
- Prevent recreated surface/texture player views from falling back to the default fit mode.

## Test plan
- Verified locally in an Android app using `resizeMode="cover"` while the native player view is recreated.