### PR TITLE
fix(android): merge sideloaded subtitle tracks via MergingMediaSource; guard PiP activity lookup

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/PictureInPictureUtil.kt
@@ -24,13 +24,18 @@ import com.brentvatne.common.toolbox.DebugLog
 import com.brentvatne.receiver.PictureInPictureReceiver
 import com.facebook.react.uimanager.ThemedReactContext
 
-internal fun Context.findActivity(): ComponentActivity {
+internal fun Context.findActivity(): ComponentActivity? {
     var context = this
     while (context is ContextWrapper) {
         if (context is ComponentActivity) return context
         context = context.baseContext
     }
-    throw IllegalStateException("Picture in picture should be called in the context of an Activity")
+    // Fallback: ThemedReactContext stores the activity separately from the ContextWrapper chain
+    if (this is ThemedReactContext) {
+        val activity = this.getCurrentActivity()
+        if (activity is ComponentActivity) return activity
+    }
+    return null
 }
 
 object PictureInPictureUtil {
@@ -39,7 +44,7 @@ object PictureInPictureUtil {
 
     @JvmStatic
     fun addLifecycleEventListener(context: ThemedReactContext, view: ReactExoplayerView): Runnable {
-        val activity = context.findActivity()
+        val activity = context.findActivity() ?: return Runnable {}
 
         val onPictureInPictureModeChanged = Consumer<PictureInPictureModeChangedInfo> { info ->
             view.setIsInPictureInPicture(info.isInPictureInPictureMode)
@@ -73,16 +78,17 @@ object PictureInPictureUtil {
     @JvmStatic
     fun enterPictureInPictureMode(context: ThemedReactContext, pictureInPictureParams: PictureInPictureParams?) {
         if (!isSupportPictureInPicture(context)) return
+        val activity = context.findActivity() ?: return
         if (isSupportPictureInPictureAction() && pictureInPictureParams != null) {
             try {
-                context.findActivity().enterPictureInPictureMode(pictureInPictureParams)
+                activity.enterPictureInPictureMode(pictureInPictureParams)
             } catch (e: IllegalStateException) {
                 DebugLog.e(TAG, e.toString())
             }
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             try {
                 @Suppress("DEPRECATION")
-                context.findActivity().enterPictureInPictureMode()
+                activity.enterPictureInPictureMode()
             } catch (e: IllegalStateException) {
                 DebugLog.e(TAG, e.toString())
             }
@@ -119,8 +125,9 @@ object PictureInPictureUtil {
     private fun updatePictureInPictureActions(context: ThemedReactContext, pipParams: PictureInPictureParams) {
         if (!isSupportPictureInPictureAction()) return
         if (!isSupportPictureInPicture(context)) return
+        val activity = context.findActivity() ?: return
         try {
-            context.findActivity().setPictureInPictureParams(pipParams)
+            activity.setPictureInPictureParams(pipParams)
         } catch (e: IllegalStateException) {
             DebugLog.e(TAG, e.toString())
         }
@@ -196,7 +203,7 @@ object PictureInPictureUtil {
     }
 
     private fun checkIsUserAllowPIP(context: ThemedReactContext): Boolean {
-        val activity = context.currentActivity ?: return false
+        val activity = context.getCurrentActivity() ?: return false
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             @SuppressLint("InlinedApi")
             val result = AppOpsManagerCompat.noteOpNoThrow(

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1147,12 +1147,18 @@ public class ReactExoplayerView extends FrameLayout implements
                 ? overridenMediaItemBuilder.build()
                 : mediaItemBuilder.build();
 
+        // Strip subtitle configurations before handing the MediaItem to the factory so that
+        // no factory variant (including overridden DefaultMediaSourceFactory) creates its own
+        // subtitle sources via legacy paths. We handle all subtitle merging below.
+        MediaItem mediaItemForSource = mediaItem.buildUpon()
+                .setSubtitleConfigurations(ImmutableList.of())
+                .build();
         MediaSource mediaSource = mediaSourceFactory
                 .setDrmSessionManagerProvider(drmProvider)
                 .setLoadErrorHandlingPolicy(
                         config.buildLoadErrorHandlingPolicy(source.getMinLoadRetryCount())
                 )
-                .createMediaSource(mediaItem);
+                .createMediaSource(mediaItemForSource);
 
         // ProgressiveMediaSource.Factory (and HLS/DASH variants) silently ignore
         // MediaItem.SubtitleConfiguration entries. Manually merge sideloaded subtitle
@@ -1160,22 +1166,28 @@ public class ReactExoplayerView extends FrameLayout implements
         if (mediaItem.localConfiguration != null && !mediaItem.localConfiguration.subtitleConfigurations.isEmpty()) {
             DataSource.Factory subtitleDataSourceFactory = buildDataSourceFactory(false);
             DefaultSubtitleParserFactory subtitleParserFactory = new DefaultSubtitleParserFactory();
-            int subtitleCount = mediaItem.localConfiguration.subtitleConfigurations.size();
-            MediaSource[] mergedSources = new MediaSource[1 + subtitleCount];
-            mergedSources[0] = mediaSource;
-            for (int i = 0; i < subtitleCount; i++) {
-                MediaItem.SubtitleConfiguration subtitleConfig = mediaItem.localConfiguration.subtitleConfigurations.get(i);
+            List<MediaSource> mergedSources = new ArrayList<>();
+            mergedSources.add(mediaSource);
+            for (MediaItem.SubtitleConfiguration subtitleConfig : mediaItem.localConfiguration.subtitleConfigurations) {
                 Format subtitleFormat = new Format.Builder()
                         .setSampleMimeType(subtitleConfig.mimeType)
                         .setLanguage(subtitleConfig.language)
                         .setLabel(subtitleConfig.label)
+                        .setSelectionFlags(subtitleConfig.selectionFlags)
+                        .setRoleFlags(subtitleConfig.roleFlags)
                         .build();
-                mergedSources[i + 1] = new ProgressiveMediaSource.Factory(
+                if (!subtitleParserFactory.supportsFormat(subtitleFormat)) {
+                    DebugLog.w(TAG, "Skipping sideloaded subtitle track with unsupported format: " + subtitleConfig.mimeType);
+                    continue;
+                }
+                mergedSources.add(new ProgressiveMediaSource.Factory(
                         subtitleDataSourceFactory,
                         () -> new Extractor[]{new SubtitleExtractor(subtitleParserFactory.create(subtitleFormat), subtitleFormat)}
-                ).createMediaSource(MediaItem.fromUri(subtitleConfig.uri));
+                ).createMediaSource(MediaItem.fromUri(subtitleConfig.uri)));
             }
-            mediaSource = new MergingMediaSource(mergedSources);
+            if (mergedSources.size() > 1) {
+                mediaSource = new MergingMediaSource(mergedSources.toArray(new MediaSource[0]));
+            }
         }
 
         if (cropStartMs >= 0 && cropEndMs >= 0) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -88,6 +88,9 @@ import androidx.media3.exoplayer.source.ClippingMediaSource;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.exoplayer.source.MediaSource;
 import androidx.media3.exoplayer.source.MergingMediaSource;
+import androidx.media3.extractor.Extractor;
+import androidx.media3.extractor.text.DefaultSubtitleParserFactory;
+import androidx.media3.extractor.text.SubtitleExtractor;
 import androidx.media3.exoplayer.source.ProgressiveMediaSource;
 import androidx.media3.exoplayer.source.TrackGroupArray;
 import androidx.media3.exoplayer.source.ads.AdsMediaSource;
@@ -1150,6 +1153,30 @@ public class ReactExoplayerView extends FrameLayout implements
                         config.buildLoadErrorHandlingPolicy(source.getMinLoadRetryCount())
                 )
                 .createMediaSource(mediaItem);
+
+        // ProgressiveMediaSource.Factory (and HLS/DASH variants) silently ignore
+        // MediaItem.SubtitleConfiguration entries. Manually merge sideloaded subtitle
+        // sources so they appear in MappedTrackInfo and can be selected via setSelectedTextTrack.
+        if (mediaItem.localConfiguration != null && !mediaItem.localConfiguration.subtitleConfigurations.isEmpty()) {
+            DataSource.Factory subtitleDataSourceFactory = buildDataSourceFactory(false);
+            DefaultSubtitleParserFactory subtitleParserFactory = new DefaultSubtitleParserFactory();
+            int subtitleCount = mediaItem.localConfiguration.subtitleConfigurations.size();
+            MediaSource[] mergedSources = new MediaSource[1 + subtitleCount];
+            mergedSources[0] = mediaSource;
+            for (int i = 0; i < subtitleCount; i++) {
+                MediaItem.SubtitleConfiguration subtitleConfig = mediaItem.localConfiguration.subtitleConfigurations.get(i);
+                Format subtitleFormat = new Format.Builder()
+                        .setSampleMimeType(subtitleConfig.mimeType)
+                        .setLanguage(subtitleConfig.language)
+                        .setLabel(subtitleConfig.label)
+                        .build();
+                mergedSources[i + 1] = new ProgressiveMediaSource.Factory(
+                        subtitleDataSourceFactory,
+                        () -> new Extractor[]{new SubtitleExtractor(subtitleParserFactory.create(subtitleFormat), subtitleFormat)}
+                ).createMediaSource(MediaItem.fromUri(subtitleConfig.uri));
+            }
+            mediaSource = new MergingMediaSource(mergedSources);
+        }
 
         if (cropStartMs >= 0 && cropEndMs >= 0) {
             return new ClippingMediaSource(mediaSource, cropStartMs * 1000, cropEndMs * 1000);


### PR DESCRIPTION
## Problem

External subtitle/caption files passed via `textTracks` never appeared on Android. Two related bugs:

**Bug 1 — Subtitles silently ignored**
`ProgressiveMediaSource.Factory` (and the HLS/DASH variants) ignore `MediaItem.SubtitleConfiguration` entries entirely. Subtitles set via `setSubtitleConfigurations` are attached to the `MediaItem` but never loaded into `MappedTrackInfo`, so `setSelectedTextTrack` has nothing to select.

Reported in #4792 and #4614.

**Bug 2 — PiP crash after subtitle change**
`findActivity()` threw `IllegalStateException` when the `ComponentActivity` wasn't reachable through the `ContextWrapper` chain. This surface became more likely after the subtitle fix changes ExoPlayer's internal session/lifecycle state via `MergingMediaSource`.

## Fix

**Subtitle fix (`ReactExoplayerView.java`)**

After the primary `MediaSource` is built, check for `SubtitleConfiguration` entries on the `MediaItem`. For each one, create a dedicated `ProgressiveMediaSource` backed by a `SubtitleExtractor`, then merge all sources with `MergingMediaSource`. This makes sideloaded tracks appear in `MappedTrackInfo` and respond to `setSelectedTextTrack` exactly like embedded tracks.

```java
if (mediaItem.localConfiguration != null && !mediaItem.localConfiguration.subtitleConfigurations.isEmpty()) {
    // build one ProgressiveMediaSource per subtitle, merge with video source
    mediaSource = new MergingMediaSource(mergedSources);
}
```

**PiP fix (`PictureInPictureUtil.kt`)**

- `findActivity()` now returns `ComponentActivity?` instead of throwing, with a `ThemedReactContext.getCurrentActivity()` fallback
- All call sites updated to handle null with early returns
- Replaces deprecated `context.currentActivity` field with `context.getCurrentActivity()`

## Testing

Verified on a physical Android device (arm64-v8a) with external `.vtt` subtitle files. Subtitles now load and are selectable. PiP entry/exit no longer crashes after subtitles are active.

Closes #4792
Related: #4614