### PR TITLE
fix(android): controls always show in fullscreen

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -451,20 +451,18 @@ public class ReactExoplayerView extends FrameLayout implements
 
     private void updateControllerConfig() {
         if (exoPlayerView == null) return;
-        
-        // Extra configuration for proper touch handling
+
         exoPlayerView.setControllerShowTimeoutMs(5000);
         exoPlayerView.setControllerAutoShow(true);
         exoPlayerView.setControllerHideOnTouch(true);
-        
+
         updateControllerVisibility();
     }
 
     private void updateControllerVisibility() {
         if (exoPlayerView == null) return;
-        
-        boolean shouldShowControls = controls || isFullscreen;
-        exoPlayerView.setUseController(shouldShowControls);
+
+        exoPlayerView.setUseController(controls || isFullscreen);
     }
 
     private void openSettings() {
@@ -520,7 +518,6 @@ public class ReactExoplayerView extends FrameLayout implements
 
     private void refreshControlsStyles() {
         if (exoPlayerView == null || player == null) return;
-        // Always update controller visibility to ensure it matches current state
         updateControllerVisibility();
     }
 
@@ -2663,10 +2660,7 @@ public class ReactExoplayerView extends FrameLayout implements
                     setFullscreen(false);
                 }
             }, controlsConfig);
-            updateControllerConfig();
-            if (exoPlayerView != null) {
-                exoPlayerView.showController();
-            }
+            refreshControlsStyles();
             eventEmitter.onVideoFullscreenPlayerWillPresent.invoke();
             if (fullScreenPlayerView != null) {
                 fullScreenPlayerView.show();


### PR DESCRIPTION
Fixes #4734
Closes #4751

## Summary

This is a rebase of the stale [PR #4813](https://github.com/TheWidlarzGroup/react-native-video/pull/4813) by @robertert (preserved as the first commit, original authorship intact), with the second commit addressing the review feedback from @moskalakamil:

- Drop the two inline explanatory comments
- Inline the `shouldShowControls` boolean in `updateControllerVisibility`
- Replace the explicit `updateControllerConfig()` + `exoPlayerView.showController()` on fullscreen entry with `refreshControlsStyles()`, which (after the first commit removes the `!controls` guard) refreshes visibility unconditionally