### PR TITLE
Fix iOS player view controller containment

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1109,7 +1109,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 if let playerViewController = _playerViewController {
                     if _controls {
                         // prevents crash https://github.com/TheWidlarzGroup/react-native-video/issues/3040
-                        self._playerViewController?.removeFromParent()
+                        playerViewController.willMove(toParent: nil)
+                        playerViewController.removeFromParent()
                     }
 
                     viewController.present(playerViewController, animated: true, completion: { [weak self] in
@@ -1190,6 +1191,9 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 _playerViewController.view.topAnchor.constraint(equalTo: self.topAnchor),
                 _playerViewController.view.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             ])
+            if let viewController {
+                _playerViewController.didMove(toParent: viewController)
+            }
         }
 
         _playerObserver.playerViewController = _playerViewController
@@ -1256,6 +1260,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 }
             } else {
                 DispatchQueue.main.async {
+                    self._playerViewController?.willMove(toParent: nil)
                     self._playerViewController?.view.removeFromSuperview()
                     self._playerViewController?.removeFromParent()
                     self._playerViewController = nil
@@ -1455,6 +1460,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         self.removePlayerLayer()
 
         if let _playerViewController {
+            _playerViewController.willMove(toParent: nil)
             _playerViewController.view.removeFromSuperview()
             _playerViewController.removeFromParent()
             _playerViewController.rctDelegate = nil


### PR DESCRIPTION
## Summary
- Call `didMove(toParent:)` after embedding the iOS `AVPlayerViewController` for native controls.
- Pair controller removals with `willMove(toParent: nil)` before detaching/removing the controller.
- Backports the proper containment lifecycle pattern already used on the v7/master implementation to the 6.x support branch.

Fixes #3138

## Test Plan
- `git diff --check`
- `xcodebuild -list -project ios/RCTVideo.xcodeproj`
- `xcodebuild -project ios/RCTVideo.xcodeproj -scheme RCTVideo -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build` *(fails in this standalone clone because React and generated bridge headers are unavailable: `unable to resolve module dependency: React` and `RCTVideoSwiftLog.h file not found`)*

## Notes
This keeps the change scoped to UIKit containment lifecycle. `AVPlayerViewController` relies on being correctly added as a child view controller, and the 6.x branch was missing the `didMove(toParent:)` call after `addChild`.