### PR TITLE
fix: preserve playback & audio state across background and Picture-in-Picture transitions

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
@@ -9,6 +9,7 @@ import com.margelo.nitro.NitroModules
 import com.margelo.nitro.video.HybridVideoPlayer
 import com.margelo.nitro.video.MixAudioMode
 import com.twg.video.core.plugins.PluginsRegistry
+import com.twg.video.core.utils.PictureInPictureUtils
 import com.twg.video.view.VideoView
 import java.lang.ref.WeakReference
 
@@ -211,6 +212,23 @@ object VideoManager : LifecycleEventListener {
 
   fun getVideoViewWeakReferenceByNitroId(nitroId: Int): WeakReference<VideoView>? {
     return views[nitroId]
+  }
+
+  // Keep the activity's auto-enter-PiP flag in sync, following the same authority as the
+  // rest of PiP: the last-played video (the user's last interaction). PiP is per-activity,
+  // so only that one video drives auto-enter — not whichever player last changed state.
+  // Gating on its playWhenReady (so a paused video doesn't auto-enter) happens inside
+  // createPictureInPictureParams.
+  fun refreshPictureInPictureParams() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      return
+    }
+
+    val view = getLastPlayedVideoView()?.takeIf {
+      it.pictureInPictureEnabled && it.autoEnterPictureInPicture
+    } ?: return
+
+    PictureInPictureUtils.safeSetPictureInPictureParams(PictureInPictureUtils.createPictureInPictureParams(view))
   }
 
   // ------------ Lifecycle Handler ------------

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
@@ -245,14 +245,21 @@ object VideoManager : LifecycleEventListener {
   }
 
   private fun onAppEnterBackground() {
-    // Entering PiP also pauses the activity, but the video must keep playing in the
-    // PiP window — so never auto-pause while the activity is (entering) PiP.
+    // Keep the PiP video playing, but still auto-pause every other non-background player. If no
+    // PiP player is designated yet (auto-enter can race it), pause nothing rather than risk it.
     val activity = try { NitroModules.applicationContext?.currentActivity } catch (_: Exception) { null }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true) {
-      return
+    val inPip = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true
+    val pipPlayer = if (inPip) {
+      getCurrentPictureInPictureVideo()?.hybridPlayer ?: return
+    } else {
+      null
     }
 
     players.keys.forEach { player ->
+      if (player == pipPlayer) {
+        return@forEach
+      }
+
       if (!player.playInBackground && player.isPlaying) {
         player.wasAutoPaused = true
         player.pause()

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
@@ -214,23 +214,20 @@ object VideoManager : LifecycleEventListener {
     return views[nitroId]
   }
 
-  // Keep the activity's auto-enter-PiP flag in sync, following the same authority as the
-  // rest of PiP: the last-played video (the user's last interaction). PiP is per-activity,
-  // so only that one video drives auto-enter — not whichever player last changed state.
-  // setPictureInPictureParams merges, so set params explicitly every time: when the
-  // last-played view shouldn't drive auto-enter we actively disable it, otherwise a value an
-  // earlier view enabled would linger. (Gating on playWhenReady happens in createPictureInPictureParams.)
+  // Keep the activity's auto-enter-PiP flag synced to the last-played video (the PiP
+  // authority — per-activity, only one video drives auto-enter). setPictureInPictureParams
+  // merges, so always set params explicitly: disable auto-enter when there is no last-played
+  // video or it shouldn't drive PiP, otherwise a flag an earlier view enabled would linger.
+  // (Gating on playWhenReady happens in createPictureInPictureParams.)
   fun refreshPictureInPictureParams() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return
     }
 
-    val view = getLastPlayedVideoView() ?: return
-
-    val params = if (view.pictureInPictureEnabled) {
-      PictureInPictureUtils.createPictureInPictureParams(view)
-    } else {
-      PictureInPictureUtils.createDisabledPictureInPictureParams(view)
+    val view = getLastPlayedVideoView()
+    val params = when {
+      view == null || !view.pictureInPictureEnabled -> PictureInPictureUtils.createDisabledPictureInPictureParams()
+      else -> PictureInPictureUtils.createPictureInPictureParams(view)
     }
 
     PictureInPictureUtils.safeSetPictureInPictureParams(params)

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
@@ -217,6 +217,8 @@ object VideoManager : LifecycleEventListener {
     players.keys.forEach { player ->
       if (player.wasAutoPaused) {
         player.play()
+        // Clear so a later manual pause isn't wrongly auto-resumed on the next foreground.
+        player.wasAutoPaused = false
       }
     }
   }
@@ -224,7 +226,7 @@ object VideoManager : LifecycleEventListener {
   private fun onAppEnterBackground() {
     players.keys.forEach { player ->
       if (!player.playInBackground && player.isPlaying) {
-        player.wasAutoPaused = player.isPlaying
+        player.wasAutoPaused = true
         player.pause()
       }
     }

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
@@ -217,18 +217,23 @@ object VideoManager : LifecycleEventListener {
   // Keep the activity's auto-enter-PiP flag in sync, following the same authority as the
   // rest of PiP: the last-played video (the user's last interaction). PiP is per-activity,
   // so only that one video drives auto-enter — not whichever player last changed state.
-  // Gating on its playWhenReady (so a paused video doesn't auto-enter) happens inside
-  // createPictureInPictureParams.
+  // setPictureInPictureParams merges, so set params explicitly every time: when the
+  // last-played view shouldn't drive auto-enter we actively disable it, otherwise a value an
+  // earlier view enabled would linger. (Gating on playWhenReady happens in createPictureInPictureParams.)
   fun refreshPictureInPictureParams() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return
     }
 
-    val view = getLastPlayedVideoView()?.takeIf {
-      it.pictureInPictureEnabled && it.autoEnterPictureInPicture
-    } ?: return
+    val view = getLastPlayedVideoView() ?: return
 
-    PictureInPictureUtils.safeSetPictureInPictureParams(PictureInPictureUtils.createPictureInPictureParams(view))
+    val params = if (view.pictureInPictureEnabled) {
+      PictureInPictureUtils.createPictureInPictureParams(view)
+    } else {
+      PictureInPictureUtils.createDisabledPictureInPictureParams(view)
+    }
+
+    PictureInPictureUtils.safeSetPictureInPictureParams(params)
   }
 
   // ------------ Lifecycle Handler ------------

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/VideoManager.kt
@@ -1,5 +1,6 @@
 package com.twg.video.core
 
+import android.os.Build
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
@@ -224,6 +225,13 @@ object VideoManager : LifecycleEventListener {
   }
 
   private fun onAppEnterBackground() {
+    // Entering PiP also pauses the activity, but the video must keep playing in the
+    // PiP window — so never auto-pause while the activity is (entering) PiP.
+    val activity = try { NitroModules.applicationContext?.currentActivity } catch (_: Exception) { null }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true) {
+      return
+    }
+
     players.keys.forEach { player ->
       if (!player.playInBackground && player.isPlaying) {
         player.wasAutoPaused = true

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/fragments/PictureInPictureHelperFragment.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/fragments/PictureInPictureHelperFragment.kt
@@ -82,10 +82,10 @@ class PictureInPictureHelperFragment(private val videoView: VideoView) : Fragmen
         videoView.exitPictureInPicture()
       }
 
-      // Closing PiP (X) leaves the activity stopped (lifecycle CREATED); expanding
-      // back to the app keeps it STARTED/RESUMED. On close, pause — don't keep
-      // playing once the user dismissed the window.
-      if (lifecycle.currentState == Lifecycle.State.CREATED) {
+      // Expanding back to the app leaves the fragment STARTED/RESUMED; closing (X) stops and
+      // finishes it (CREATED → DESTROYED). Pause whenever it is no longer started — the user
+      // dismissed the window rather than expanding it.
+      if (!lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
         videoView.hybridPlayer?.pause()
       }
     }

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/fragments/PictureInPictureHelperFragment.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/fragments/PictureInPictureHelperFragment.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.media3.common.util.UnstableApi
 import com.twg.video.core.VideoManager
 import com.twg.video.view.VideoView
@@ -79,6 +80,13 @@ class PictureInPictureHelperFragment(private val videoView: VideoView) : Fragmen
     } else {
       if (videoView.isInPictureInPicture) {
         videoView.exitPictureInPicture()
+      }
+
+      // Closing PiP (X) leaves the activity stopped (lifecycle CREATED); expanding
+      // back to the app keeps it STARTED/RESUMED. On close, pause — don't keep
+      // playing once the user dismissed the window.
+      if (lifecycle.currentState == Lifecycle.State.CREATED) {
+        videoView.hybridPlayer?.pause()
       }
     }
   }

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/utils/PictureInPictureUtils.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/utils/PictureInPictureUtils.kt
@@ -27,8 +27,15 @@ object PictureInPictureUtils {
   fun createPictureInPictureParams(videoView: VideoView): PictureInPictureParams {
     val builder = PictureInPictureParams.Builder()
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && videoView.autoEnterPictureInPicture) {
-      builder.setAutoEnterEnabled(videoView.autoEnterPictureInPicture)
+    // Auto-enter PiP only when the user intends playback — matches iOS, which never
+    // auto-enters PiP for a paused player. Gate on playWhenReady (not isPlaying) so a
+    // buffering-but-intending-to-play video still enters PiP. Refreshed on play/pause
+    // via VideoManager. Must set explicitly (also false): setPictureInPictureParams
+    // merges, so omitting it would leave a previously-enabled value in place.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      builder.setAutoEnterEnabled(
+        videoView.autoEnterPictureInPicture && videoView.hybridPlayer?.player?.playWhenReady == true
+      )
     }
 
     return builder

--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/utils/PictureInPictureUtils.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/utils/PictureInPictureUtils.kt
@@ -45,7 +45,7 @@ object PictureInPictureUtils {
   }
 
   @RequiresApi(Build.VERSION_CODES.O)
-  fun createDisabledPictureInPictureParams(videoView: VideoView): PictureInPictureParams {
+  fun createDisabledPictureInPictureParams(): PictureInPictureParams {
     val defaultParams = PictureInPictureParams.Builder()
       .setAspectRatio(null) // Clear aspect ratio
       .setSourceRectHint(null) // Clear source rect hint

--- a/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
@@ -527,6 +527,18 @@ class HybridVideoPlayer() : HybridVideoPlayerSpec(), AutoCloseable {
       VideoManager.refreshPictureInPictureParams()
     }
 
+    override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+      super.onPlayWhenReadyChanged(playWhenReady, reason)
+
+      // A resume cancels a pending auto-pause, so the next foreground won't force-resume it.
+      if (playWhenReady) {
+        this@HybridVideoPlayer.wasAutoPaused = false
+      }
+
+      // playWhenReady can change without isPlaying (pause while buffering), so refresh here too.
+      VideoManager.refreshPictureInPictureParams()
+    }
+
     override fun onPlayerError(error: PlaybackException) {
       status = VideoPlayerStatus.ERROR
       stopProgressUpdates()

--- a/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
@@ -523,6 +523,8 @@ class HybridVideoPlayer() : HybridVideoPlayerSpec(), AutoCloseable {
           stopProgressUpdates()
         }
       }
+      // Keep the activity's auto-enter-PiP flag in sync with the last-played video.
+      VideoManager.refreshPictureInPictureParams()
     }
 
     override fun onPlayerError(error: PlaybackException) {

--- a/packages/react-native-video/android/src/main/java/com/twg/video/view/VideoView.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/view/VideoView.kt
@@ -79,7 +79,7 @@ class VideoView @JvmOverloads constructor(
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         PictureInPictureUtils.safeSetPictureInPictureParams(
           if (value) createPictureInPictureParams(this)
-          else createDisabledPictureInPictureParams(this)
+          else createDisabledPictureInPictureParams()
         )
       }
     }
@@ -537,7 +537,7 @@ class VideoView @JvmOverloads constructor(
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       PictureInPictureUtils.safeSetPictureInPictureParams(
-        createDisabledPictureInPictureParams(this)
+        createDisabledPictureInPictureParams()
       )
     }
 

--- a/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
+++ b/packages/react-native-video/ios/core/NowPlayingInfoCenterManager.swift
@@ -157,6 +157,7 @@ class NowPlayingInfoCenterManager {
 
       if player.rate != 0 {
         player.pause()
+        VideoManager.shared.clearBackgroundResumeIntent(for: player)
       }
 
       return .success
@@ -212,6 +213,7 @@ class NowPlayingInfoCenterManager {
         player.play()
       } else {
         player.pause()
+        VideoManager.shared.clearBackgroundResumeIntent(for: player)
       }
 
       return .success

--- a/packages/react-native-video/ios/core/VideoManager.swift
+++ b/packages/react-native-video/ios/core/VideoManager.swift
@@ -240,6 +240,14 @@ class VideoManager {
       break
     }
     
+    // setCategory is a relatively expensive IPC and this runs on every audio-session refresh —
+    // skip it when nothing changed (category/mode/options are readable, unlike the active state).
+    if audioSession.category == category
+      && audioSession.mode == .moviePlayback
+      && audioSession.categoryOptions == audioSessionCategoryOptions {
+      return
+    }
+
     do {
       try audioSession.setCategory(category, mode: .moviePlayback, options: audioSessionCategoryOptions)
     } catch {

--- a/packages/react-native-video/ios/core/VideoManager.swift
+++ b/packages/react-native-video/ios/core/VideoManager.swift
@@ -419,21 +419,27 @@ class VideoManager {
     // Pause all players when the app enters background
     for player in players.allObjects {
       if player.playInBackground || player.player.isExternalPlaybackActive == true || !player.isPlaying {
+        player.wasPlayingInBackground = player.playInBackground && player.isPlaying
         continue
       }
-      
+
       try? player.pause()
       player.wasAutoPaused = true
     }
   }
-  
+
   @objc func applicationWillEnterForeground(notification: Notification) {
     // Resume all players when the app enters foreground
     for player in players.allObjects {
       if player.wasAutoPaused {
         try? player.play()
         player.wasAutoPaused = false
+      } else if player.wasPlayingInBackground && !player.isPlaying {
+        // Was playing when backgrounded but the system paused it — resume.
+        try? player.play()
       }
+
+      player.wasPlayingInBackground = false
     }
   }
 }

--- a/packages/react-native-video/ios/core/VideoManager.swift
+++ b/packages/react-native-video/ios/core/VideoManager.swift
@@ -140,10 +140,8 @@ class VideoManager {
   
   // MARK: - Audio Session Management
   private func activateAudioSession() {
-    if isAudioSessionActive {
-      return
-    }
-
+    // No early-return: there's no public `isActive` getter, so the cached flag goes stale
+    // when the system deactivates the session (e.g. while suspended). setActive(true) is idempotent.
     do {
       try AVAudioSession.sharedInstance().setActive(true)
       isAudioSessionActive = true
@@ -461,9 +459,7 @@ class VideoManager {
       player.wasPlayingInBackground = false
     }
 
-    // Force re-activation: the session may have been deactivated while
-    // backgrounded, leaving the cached `isAudioSessionActive` stale.
-    isAudioSessionActive = false
+    // Re-assert the session — it may have been deactivated by the system while backgrounded.
     updateAudioSessionConfiguration()
   }
 }

--- a/packages/react-native-video/ios/core/VideoManager.swift
+++ b/packages/react-native-video/ios/core/VideoManager.swift
@@ -358,7 +358,8 @@ class VideoManager {
     
     switch type {
     case .began:
-      // Audio session interrupted, nothing to do as players will pause automatically
+      // The interruption deactivated our session — keep the cache honest.
+      isAudioSessionActive = false
       break
       
     case .ended:
@@ -441,5 +442,10 @@ class VideoManager {
 
       player.wasPlayingInBackground = false
     }
+
+    // Force re-activation: the session may have been deactivated while
+    // backgrounded, leaving the cached `isAudioSessionActive` stale.
+    isAudioSessionActive = false
+    updateAudioSessionConfiguration()
   }
 }

--- a/packages/react-native-video/ios/core/VideoManager.swift
+++ b/packages/react-native-video/ios/core/VideoManager.swift
@@ -119,7 +119,15 @@ class VideoManager {
   func requestAudioSessionUpdate() {
     updateAudioSessionConfiguration()
   }
-  
+
+  /// Clears the resume intent for the player backing `avPlayer` — for remote
+  /// (lock screen / Control Center / headset) pauses, which bypass `pause()`.
+  func clearBackgroundResumeIntent(for avPlayer: AVPlayer) {
+    for player in players.allObjects where player.player === avPlayer {
+      player.wasPlayingInBackground = false
+    }
+  }
+
   // MARK: - Remote Control Events
   func setRemoteControlEventsActive(_ active: Bool) {
     if isAudioSessionManagementDisabled || remoteControlEventsActive == active {
@@ -360,6 +368,10 @@ class VideoManager {
     case .began:
       // The interruption deactivated our session — keep the cache honest.
       isAudioSessionActive = false
+      // Not a system background pause; don't auto-resume after an interruption.
+      for player in players.allObjects {
+        player.wasPlayingInBackground = false
+      }
       break
       
     case .ended:
@@ -386,7 +398,13 @@ class VideoManager {
     }
     
     switch reason {
-    case .categoryChange, .override, .wakeFromSleep, .newDeviceAvailable, .oldDeviceUnavailable:
+    case .oldDeviceUnavailable:
+      // Output device removed (e.g. headphones) — iOS pauses; don't resume onto the speaker.
+      for player in players.allObjects {
+        player.wasPlayingInBackground = false
+      }
+      updateAudioSessionConfiguration()
+    case .categoryChange, .override, .wakeFromSleep, .newDeviceAvailable:
       // Reconfigure audio session when route changes
       updateAudioSessionConfiguration()
     default:

--- a/packages/react-native-video/ios/core/VideoPlayerObserver.swift
+++ b/packages/react-native-video/ios/core/VideoPlayerObserver.swift
@@ -96,13 +96,12 @@ class VideoPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVP
       self?.onPlayerCurrentItemChanged(player: player, change: change)
     }
     
-    // Observe rate via the rate-change notification instead of KVO of \.rate: it fires on the same
-    // rate changes but also carries the reason (.setRateCalled vs .appBackgrounded), which the
-    // delegate uses for background-resume decisions. Available since iOS 15.
+    // Rate-change notification (not KVO of \.rate) carries the reason (.setRateCalled vs
+    // .appBackgrounded), used for background-resume decisions.
     playerRateObserver = NotificationCenter.default.addObserver(
       forName: AVPlayer.rateDidChangeNotification,
       object: player,
-      queue: .main
+      queue: nil
     ) { [weak self] notification in
       guard let self, let player = self.player else { return }
       let reason = notification.userInfo?[AVPlayer.rateDidChangeReasonKey] as? AVPlayer.RateDidChangeReason

--- a/packages/react-native-video/ios/core/VideoPlayerObserver.swift
+++ b/packages/react-native-video/ios/core/VideoPlayerObserver.swift
@@ -14,7 +14,7 @@ protocol VideoPlayerObserverDelegate: AnyObject {
   func onPlayerItemWillChange(hasNewPlayerItem: Bool)
   func onTextTrackDataChanged(texts: [NSAttributedString])
   func onTimedMetadataChanged(timedMetadata: [AVMetadataItem])
-  func onRateChanged(rate: Float)
+  func onRateChanged(rate: Float, reason: AVPlayer.RateDidChangeReason?)
   func onPlaybackBufferEmpty()
   func onPlaybackLikelyToKeepUp()
   func onVolumeChanged(volume: Float)
@@ -32,7 +32,7 @@ extension VideoPlayerObserverDelegate {
   func onPlayerItemWillChange(hasNewPlayerItem: Bool) {}
   func onTextTrackDataChanged(texts: [NSAttributedString]) {}
   func onTimedMetadataChanged(timedMetadata: [AVMetadataItem]) {}
-  func onRateChanged(rate: Float) {}
+  func onRateChanged(rate: Float, reason: AVPlayer.RateDidChangeReason?) {}
   func onPlaybackBufferEmpty() {}
   func onPlaybackLikelyToKeepUp() {}
   func onVolumeChanged(volume: Float) {}
@@ -52,14 +52,13 @@ class VideoPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVP
   
   // Player observers
   var playerCurrentItemObserver: NSKeyValueObservation?
-  var playerRateObserver: NSKeyValueObservation?
+  var playerRateObserver: NSObjectProtocol?
   var playerTimeControlStatusObserver: NSKeyValueObservation?
   var playerExternalPlaybackActiveObserver: NSKeyValueObservation?
   var playerVolumeObserver: NSKeyValueObservation?
   var playerTimedMetadataObserver: NSKeyValueObservation?
   var playerStatusObserver: NSKeyValueObservation?
   var playerProgressPeriodicObserver: Any?
-  var playerRateReasonObserver: NSObjectProtocol?
 
   // Player item observers
   var playbackEndedObserver: NSObjectProtocol?
@@ -97,24 +96,17 @@ class VideoPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVP
       self?.onPlayerCurrentItemChanged(player: player, change: change)
     }
     
-    playerRateObserver = player.observe(\.rate, options: [.new]) { [weak self] _, change in
-      guard let rate = change.newValue else { return }
-      self?.delegate?.onRateChanged(rate: rate)
-    }
-
-    // A deliberate pause (PiP controls, app UI, lock screen) sets rate to 0 via setRate, reported
-    // as .setRateCalled; a system background pause reports .appBackgrounded. Only the former should
-    // cancel the background-resume intent, so a video paused inside PiP isn't auto-resumed on return.
-    playerRateReasonObserver = NotificationCenter.default.addObserver(
+    // Observe rate via the rate-change notification instead of KVO of \.rate: it fires on the same
+    // rate changes but also carries the reason (.setRateCalled vs .appBackgrounded), which the
+    // delegate uses for background-resume decisions. Available since iOS 15.
+    playerRateObserver = NotificationCenter.default.addObserver(
       forName: AVPlayer.rateDidChangeNotification,
       object: player,
       queue: .main
     ) { [weak self] notification in
-      guard let self, let player = self.player, player.rate == 0 else { return }
+      guard let self, let player = self.player else { return }
       let reason = notification.userInfo?[AVPlayer.rateDidChangeReasonKey] as? AVPlayer.RateDidChangeReason
-      if reason == .setRateCalled {
-        VideoManager.shared.clearBackgroundResumeIntent(for: player)
-      }
+      self.delegate?.onRateChanged(rate: player.rate, reason: reason)
     }
 
     playerTimeControlStatusObserver = player.observe(\.timeControlStatus, options: [.new]) { [weak self] _, change in
@@ -210,8 +202,10 @@ class VideoPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVP
     // Invalidate KVO observers
     playerCurrentItemObserver?.invalidate()
     playerCurrentItemObserver = nil
-    playerRateObserver?.invalidate()
-    playerRateObserver = nil
+    if let playerRateObserver {
+      NotificationCenter.default.removeObserver(playerRateObserver)
+      self.playerRateObserver = nil
+    }
     playerTimeControlStatusObserver?.invalidate()
     playerTimeControlStatusObserver = nil
     playerExternalPlaybackActiveObserver?.invalidate()
@@ -220,10 +214,6 @@ class VideoPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVP
     playerVolumeObserver = nil
     playerStatusObserver?.invalidate()
     playerStatusObserver = nil
-    if let playerRateReasonObserver {
-      NotificationCenter.default.removeObserver(playerRateReasonObserver)
-      self.playerRateReasonObserver = nil
-    }
     // Remove periodic time observer from player
     if let player = player, let periodicObserver = playerProgressPeriodicObserver {
       player.removeTimeObserver(periodicObserver)

--- a/packages/react-native-video/ios/core/VideoPlayerObserver.swift
+++ b/packages/react-native-video/ios/core/VideoPlayerObserver.swift
@@ -59,7 +59,8 @@ class VideoPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVP
   var playerTimedMetadataObserver: NSKeyValueObservation?
   var playerStatusObserver: NSKeyValueObservation?
   var playerProgressPeriodicObserver: Any?
-  
+  var playerRateReasonObserver: NSObjectProtocol?
+
   // Player item observers
   var playbackEndedObserver: NSObjectProtocol?
   var playbackBufferEmptyObserver: NSKeyValueObservation?
@@ -100,7 +101,22 @@ class VideoPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVP
       guard let rate = change.newValue else { return }
       self?.delegate?.onRateChanged(rate: rate)
     }
-    
+
+    // A deliberate pause (PiP controls, app UI, lock screen) sets rate to 0 via setRate, reported
+    // as .setRateCalled; a system background pause reports .appBackgrounded. Only the former should
+    // cancel the background-resume intent, so a video paused inside PiP isn't auto-resumed on return.
+    playerRateReasonObserver = NotificationCenter.default.addObserver(
+      forName: AVPlayer.rateDidChangeNotification,
+      object: player,
+      queue: .main
+    ) { [weak self] notification in
+      guard let self, let player = self.player, player.rate == 0 else { return }
+      let reason = notification.userInfo?[AVPlayer.rateDidChangeReasonKey] as? AVPlayer.RateDidChangeReason
+      if reason == .setRateCalled {
+        VideoManager.shared.clearBackgroundResumeIntent(for: player)
+      }
+    }
+
     playerTimeControlStatusObserver = player.observe(\.timeControlStatus, options: [.new]) { [weak self] _, change in
       guard let status = change.newValue else { return }
       self?.delegate?.onTimeControlStatusChanged(status: status)
@@ -204,6 +220,10 @@ class VideoPlayerObserver: NSObject, AVPlayerItemMetadataOutputPushDelegate, AVP
     playerVolumeObserver = nil
     playerStatusObserver?.invalidate()
     playerStatusObserver = nil
+    if let playerRateReasonObserver {
+      NotificationCenter.default.removeObserver(playerRateReasonObserver)
+      self.playerRateReasonObserver = nil
+    }
     // Remove periodic time observer from player
     if let player = player, let periodicObserver = playerProgressPeriodicObserver {
       player.removeTimeObserver(periodicObserver)

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
@@ -23,10 +23,17 @@ extension HybridVideoPlayer: VideoPlayerObserverDelegate {
     }
   }
 
-  func onRateChanged(rate: Float) {
+  func onRateChanged(rate: Float, reason: AVPlayer.RateDidChangeReason?) {
     _eventEmitter?.onPlaybackRateChange(Double(rate))
     NowPlayingInfoCenterManager.shared.updatePlaybackState()
     updateAndEmitPlaybackState()
+
+    // A deliberate pause (PiP controls, app UI, lock screen) reports .setRateCalled; a system
+    // background pause reports .appBackgrounded. Only the former cancels the background-resume
+    // intent, so a video paused inside PiP isn't auto-resumed on return.
+    if rate == 0, reason == .setRateCalled {
+      wasPlayingInBackground = false
+    }
   }
 
   func onVolumeChanged(volume: Float) {

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
@@ -14,6 +14,9 @@ extension HybridVideoPlayer: VideoPlayerObserverDelegate {
   func onPlayedToEnd(player: AVPlayer) {
     _eventEmitter?.onEnd()
 
+    // Finished — don't resume it on return.
+    wasPlayingInBackground = false
+
     if loop {
       currentTime = 0
       try? play()

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer+Events.swift
@@ -93,6 +93,11 @@ extension HybridVideoPlayer: VideoPlayerObserverDelegate {
     }
 
     updateAndEmitPlaybackState()
+
+    // Keep the audio session in sync with playback: starting/stopping changes whether we hold
+    // the session and the mix mode (mix-with-others vs interrupt), which is otherwise only
+    // recomputed on prop/lifecycle changes — not on play/pause.
+    VideoManager.shared.requestAudioSessionUpdate()
   }
 
   func onPlayerStatusChanged(status: AVPlayer.Status) {

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -166,6 +166,10 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
 
   var wasAutoPaused: Bool = false
 
+  /// Whether the player was playing when backgrounded — used to resume it on
+  /// return if the system paused background playback.
+  var wasPlayingInBackground: Bool = false
+
   // Text track selection state
   private var selectedExternalTrackIndex: Int? = nil
 
@@ -274,6 +278,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
   }
 
   func pause() throws {
+    wasPlayingInBackground = false
     player.pause()
   }
 


### PR DESCRIPTION
## Summary

  Playback and audio state were not reliably preserved when the app moved between
  foreground, background and Picture-in-Picture. This PR makes the playback,
  audio-session and PiP lifecycle consistent and correct, and aligns the behavior
  between iOS and Android.

  ## iOS

  - **Re-activate the audio session when returning to the foreground.** While the
    app is backgrounded/suspended the system can deactivate the session out-of-band,
    which otherwise left playback silent on return. Activation is idempotent, so
    coming back to the foreground always re-asserts the session when a player is
    playing. There is no public `AVAudioSession.isActive` getter, so we no longer
    rely on a cached flag that can go stale.
  - **Resume playback on return only when the system paused it on backgrounding** —
    not when the user paused, an audio interruption occurred (e.g. a phone call),
    the output route changed (e.g. headphones unplugged), or the item played to the
    end. Those cases intentionally stay paused.

  ## Android

  - **Keep the play/pause state when entering PiP** — the video no longer pauses on
    entry.
  - **Pause when the PiP window is closed (X), keep playing when expanding back**
    into the app.
  - **Auto-enter PiP only while the last-played video is actually playing**
    (gated on `playWhenReady`), matching iOS — a paused video no longer auto-enters
    PiP. Because `setPictureInPictureParams` merges, the auto-enter flag is set
    explicitly.
  - **Reset the auto-pause flag after a foreground resume**, so a later manual pause
    isn't wrongly auto-resumed on the next foreground.

  ## Resulting behavior (iOS & Android)

  | Transition | Result |
  | --- | --- |
  | Background while playing | keeps playing; audio remains audible on return |
  | Enter PiP | play/pause state preserved |
  | Playing → PiP / Paused → no PiP | auto-enter only while playing |
  | Close PiP (X) | playback pauses |
  | Expand PiP back to app | keeps playing |