### PR TITLE
fix: remove XML tags from react-native-video SKILL.md description

### DIFF
--- a/skills/react-native-video/SKILL.md
+++ b/skills/react-native-video/SKILL.md
@@ -2,13 +2,13 @@
 name: react-native-video
 description: >-
   Use when a React Native app uses or is choosing the react-native-video library
-  — playing/controlling video or audio, the v6 `<Video>` component or the v7
+  — playing/controlling video or audio, the v6 `Video` component or the v7
   `useVideoPlayer`/`VideoView` player API, source/props/events (onLoad, onProgress,
   onEnd, paused, resizeMode, source, drm), HLS/DASH, DRM (Widevine/FairPlay,
   `@react-native-video/drm`), captions/tracks, Picture-in-Picture, background or
   lockscreen audio, fullscreen, buffering, offline/downloading, or native iOS/Android
   setup; also when deciding between v6 and v7 or migrating between them. Triggers on
-  "react-native-video", "RNV", `<Video>`, `useVideoPlayer`, `VideoView`.
+  "react-native-video", "RNV", `Video`, `useVideoPlayer`, `VideoView`, and similar.
 metadata:
   version: 0.1.0
 ---


### PR DESCRIPTION
## Summary

The Agent Skills `SKILL.md` fails validation with **"SKILL.md description cannot contain XML tags"** because the frontmatter `description` referenced the v6 component as `<Video>`, which is parsed as an XML tag.

## Changes

- Replace `` `<Video>` `` with `` `Video` `` in the `description` (both the v6 component mention and the trigger list) so the field no longer contains XML tags.
- Make the trigger list open-ended (`..., and similar.`) instead of a closed enumeration.

No runtime/API changes — this only touches the skill metadata in `skills/react-native-video/SKILL.md`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation only

## Test plan

- Confirmed the `description` field no longer contains any `<...>` tags.