### PR TITLE
feat(github): add discussion category forms (Ideas, Q&A, Show and tell)

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,80 @@
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea for react-native-video!
+
+        **Before you post:**
+        - Search [existing ideas](https://github.com/TheWidlarzGroup/react-native-video/discussions/categories/ideas) - if it's already there, add a 👍 instead of a duplicate
+        - This is for **feature ideas**, not bugs. Found a bug? [Open a bug report](https://github.com/TheWidlarzGroup/react-native-video/issues/new?template=bug-report.yml)
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: The use case or pain point behind this idea. What are you building, and what gets in the way today?
+      placeholder: "In a TikTok-style feed I want the next video ready instantly, but there's no way to warm up a player before its view is shown."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen? A rough API shape, prop, or behavior is enough
+      placeholder: "A preload() method on the player, or a prefetch prop that starts buffering before the view mounts."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you use today, or other approaches you've thought about
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Platforms
+      description: Which platforms is this idea relevant to?
+      multiple: true
+      options:
+        - iOS
+        - Android
+        - Web
+        - visionOS
+        - Apple tvOS
+        - Android TV
+        - Windows
+    validations:
+      required: false
+
+  - type: dropdown
+    id: version-line
+    attributes:
+      label: Version line
+      description: Which version of react-native-video is this for?
+      options:
+        - v7
+        - v6
+        - Both
+        - Not sure
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links, references, or anything else that helps explain the idea
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Want this built, or need it sooner?** TheWidlarzGroup - the maintainers of react-native-video - offer [commercial support and custom development](https://sdk.thewidlarzgroup.com/issue-booster?contact=true&utm_source=rnv&utm_medium=discussion&utm_campaign=idea&utm_id=build-it).

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,71 @@
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reaching out! A few details help us answer faster.
+
+        **Before you post:**
+        - Search [existing Q&A](https://github.com/TheWidlarzGroup/react-native-video/discussions/categories/q-a) and the [docs](https://sdk.thewidlarzgroup.com/) - your question may already be answered
+        - Hitting a bug or crash? [Open a bug report](https://github.com/TheWidlarzGroup/react-native-video/issues/new?template=bug-report.yml) instead
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+      description: Describe your question or the goal you want to achieve with react-native-video
+      placeholder: "Play an HLS stream and switch audio tracks from a custom button."
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: What you've attempted so far, and what actually happens (optional)
+    validations:
+      required: false
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Relevant code
+      description: A minimal snippet of how you set up the player / Video component (optional)
+      render: tsx
+    validations:
+      required: false
+
+  - type: dropdown
+    id: version-line
+    attributes:
+      label: Version
+      description: Which version of react-native-video is your question about?
+      options:
+        - Not version-specific / not sure
+        - v7
+        - v6
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Platforms
+      description: Which platforms does your question concern? (optional)
+      multiple: true
+      options:
+        - iOS
+        - Android
+        - Web
+        - visionOS
+        - Apple tvOS
+        - Android TV
+        - Windows
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Need a faster answer or hands-on help?** TheWidlarzGroup - the maintainers of react-native-video - offer [commercial support](https://sdk.thewidlarzgroup.com/issue-booster?contact=true&utm_source=rnv&utm_medium=discussion&utm_campaign=question&utm_id=get-help).

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,39 @@
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Built something with react-native-video? We'd love to see it! 🎬
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What did you build?
+      description: Tell us about your app, feature, or experiment
+    validations:
+      required: true
+
+  - type: input
+    id: link
+    attributes:
+      label: Link / demo
+      description: App Store / Play Store / website / video / screenshots
+      placeholder: https://...
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: react-native-video version used
+      description: Which version powered it
+      placeholder: 7.0.0
+    validations:
+      required: false
+
+  - type: textarea
+    id: notable
+    attributes:
+      label: Anything notable?
+      description: Tricky problems you solved, tips, or feedback for the maintainers
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds GitHub **discussion category forms** under `.github/DISCUSSION_TEMPLATE/`, so new discussions are structured the same way our issue forms are. This mirrors the routing already in the issue chooser (`config.yml`): feature requests → **Ideas**, questions → **Q&A**.

- **`ideas.yml`** (💡 Ideas) — problem/use-case + proposed solution (required), then optional alternatives, platforms, version line, and context. Auto-labels `feature`.
- **`q-a.yml`** (❓ Q&A) — only "What are you trying to do?" is required; optional "what have you tried", code snippet, an optional **v6/v7 version** dropdown (questions are often general, so version is never required), and platforms. Auto-labels `question`.
- **`show-and-tell.yml`** (🛠️ Show and tell) — light: what you built (required) + optional link/demo, version, and notes.

## Design notes

Kept intentionally **lighter than the bug-report form** — I researched how mature projects do discussion forms (prisma, vercel/next.js, eclipse-theia) and the consistent pattern is minimal forms (often a single required field), with version optional or omitted, because discussions are conversational and heavy forms suppress participation.

Ideas/Q&A include a small commercial-support footer (consistent with the bug report). The `feature` and `question` labels already exist on the repo.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Notes

- Discussion category forms only take effect once on the **default branch**, and do not apply to the Polls category (GitHub limitation).