### PR TITLE
feat(github): add discussion welcome bot

### DIFF
--- a/.github/scripts/triage-discussion.js
+++ b/.github/scripts/triage-discussion.js
@@ -1,0 +1,48 @@
+// @ts-check
+// Welcome bot for react-native-video discussions. On a newly created discussion
+// it posts a short welcome comment (labels are handled by the category forms).
+// handleDiscussion() is the entry point and does the GitHub IO.
+
+// Per-category welcome comment, keyed by the discussion category slug.
+// Categories not listed here (Announcements, General) are left untouched.
+/** @type {Record<string, string>} */
+const COMMENT = {
+  ideas: 'Thanks for sharing this idea! 🙏 We will take a look, and others can chime in with 👍 and comments.',
+  'q-a': 'Thanks for the question! 🙏 The community and maintainers will help when they can. Once something solves it, please mark it as the answer so others can find it.',
+  'show-and-tell': 'Thanks for sharing what you built! 🎬 We love seeing react-native-video out in the wild.',
+  polls: 'Thanks for starting this poll! 🗳️ Cast your vote and let the community weigh in.',
+};
+
+/** @typedef {import('@octokit/rest').Octokit} Octokit */
+/**
+ * @typedef {Object} Discussion
+ * @property {string} node_id
+ * @property {number} number
+ * @property {{ slug?: string, name?: string }} [category]
+ */
+/**
+ * @typedef {Object} Context
+ * @property {{ owner: string, repo: string }} repo
+ * @property {{ discussion?: Discussion, action?: string }} payload
+ */
+
+const ADD_COMMENT = `mutation($id:ID!,$body:String!){
+  addDiscussionComment(input:{ discussionId:$id, body:$body }){ comment{ id } }
+}`;
+
+/** @param {{ github: Octokit, context: Context }} args */
+async function handleDiscussion({ github, context }) {
+  const discussion = context.payload.discussion;
+  if (!discussion) return;
+
+  const slug = discussion.category && discussion.category.slug;
+  const comment = slug ? COMMENT[slug] : undefined;
+  if (!comment) {
+    console.log(`No welcome comment for category "${slug}" -> skipping`);
+    return;
+  }
+
+  await github.graphql(ADD_COMMENT, { id: discussion.node_id, body: comment });
+}
+
+module.exports = handleDiscussion;

--- a/.github/workflows/triage-discussion.yml
+++ b/.github/workflows/triage-discussion.yml
@@ -1,0 +1,25 @@
+name: Triage discussion
+
+on:
+  discussion:
+    types: [created]
+
+permissions:
+  contents: read
+  discussions: write
+
+jobs:
+  triage:
+    if: ${{ github.repository == 'TheWidlarzGroup/react-native-video' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: triage-discussion-${{ github.event.discussion.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const handleDiscussion = require('./.github/scripts/triage-discussion.js')
+            await handleDiscussion({ github, context })


### PR DESCRIPTION
## Summary

A small GitHub Actions bot that runs when a **discussion is created** and posts a short welcome comment. Covers **all categories except Announcements and General**: Ideas, Q&A, Show and tell, Polls.

**Comment only - no labels.** The category forms already auto-apply labels (`feature` on Ideas, `question` on Q&A), so the bot does not duplicate them; its job is the welcome message that forms cannot post. This mirrors how the issue bot splits work: the form sets the static label, the bot only adds what the form cannot.

## Changes

- **`.github/workflows/triage-discussion.yml`** - triggers on `discussion: [created]`, guarded to the upstream repo, `permissions: { contents: read, discussions: write }`, runs the script via `actions/github-script`.
- **`.github/scripts/triage-discussion.js`** - `@ts-check` typed (Octokit, no `any`), dependency-free, ~50 lines. A per-category `slug -> comment` map drives it; Announcements/General are absent and left untouched. Posts via `addDiscussionComment`. Fires once on `created`, so no bot-comment marker is needed.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Notes

- Deterministic and ad-free (commercial links stay in the form footer, not the bot).
- Workflow only takes effect once on the **default branch**.