### PR TITLE
chore: refresh license year and fix X/Twitter link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 TheWidlarzGroup
+Copyright (c) 2024-present TheWidlarzGroup
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Contact us at [hi@thewidlarzgroup.com](mailto:hi@thewidlarzgroup.com)
 
 ## 🌍 Social
 
-- 🐦 **X / Twitter** - [follow product & release updates](https://x.com/TheWidlarzGroup)
+- 🐦 **X / Twitter** - [follow product & release updates](https://x.com/WidlarzGroup)
 - 💬 **Discord** - [talk to the community and us](https://discord.gg/9WPq6Yx)
 - 💼 **LinkedIn** - [see TWG flexing](https://linkedin.com/company/the-widlarz-group)
 


### PR DESCRIPTION
## Summary

Two small housekeeping fixes:

- **LICENSE** — switch the copyright notice from `2024-2025` to `2024-present`, so the year no longer needs a manual yearly bump. (The notice has no constitutive legal effect under the Berne Convention / Polish copyright law anyway; `present` is a widely used, zero-maintenance form.)
- **README** — fix the X/Twitter link in the Social section from `x.com/TheWidlarzGroup` to the correct company handle `x.com/WidlarzGroup`.
