### PR TITLE
fix: rebind view manager when the native view is recreated

### DIFF
--- a/packages/react-native-video/src/core/video-view/VideoView.tsx
+++ b/packages/react-native-video/src/core/video-view/VideoView.tsx
@@ -77,25 +77,30 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
   ) => {
     const nitroId = React.useMemo(() => nitroIdCounter++, []);
     const nitroViewManager = React.useRef<VideoViewViewManager | null>(null);
-    const [isManagerReady, setIsManagerReady] = React.useState(false);
+    // Counts native view generations: the native view can be deleted and
+    // recreated while this component stays mounted (for example
+    // react-native-screens detaches covered screens, deleting their Fabric
+    // views). Every onNitroIdChange marks a freshly created native view, so
+    // the manager must be recreated and all imperative bindings (player,
+    // listeners) re-applied - the previous manager points at the deallocated
+    // view.
+    const [managerGeneration, setManagerGeneration] = React.useState(0);
 
     const setupViewManager = React.useCallback(
       (id: number) => {
         try {
-          if (nitroViewManager.current === null) {
-            nitroViewManager.current =
-              VideoViewViewManagerFactory.createViewManager(id);
+          nitroViewManager.current =
+            VideoViewViewManagerFactory.createViewManager(id);
 
-            // Should never happen
-            if (!nitroViewManager.current) {
-              throw new VideoError(
-                'view/not-found',
-                'Failed to create View Manager'
-              );
-            }
+          // Should never happen
+          if (!nitroViewManager.current) {
+            throw new VideoError(
+              'view/not-found',
+              'Failed to create View Manager'
+            );
           }
 
-          setIsManagerReady(true);
+          setManagerGeneration((generation) => generation + 1);
         } catch (error) {
           const parsedError = tryParseNativeVideoError(error);
 
@@ -214,7 +219,7 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
       return () => {
         if (nitroViewManager.current) {
           nitroViewManager.current.clearAllListeners();
-          setIsManagerReady(false);
+          setManagerGeneration(0);
         }
       };
     }, []);
@@ -280,7 +285,7 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
       willExitFullscreen,
       willEnterPictureInPicture,
       willExitPictureInPicture,
-      isManagerReady,
+      managerGeneration,
     ]);
 
     // Update non-event props
@@ -305,7 +310,7 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
       autoEnterPictureInPicture,
       resizeMode,
       props,
-      isManagerReady,
+      managerGeneration,
     ]);
 
     return (


### PR DESCRIPTION
## Summary

Fixes #5018 — `VideoView` renders permanently black after react-native-screens (or anything else) deletes and recreates the underlying Fabric native view while the React component stays mounted.

`setupViewManager` previously created the `VideoViewViewManager` only once (`if (nitroViewManager.current === null)`) and gated the imperative bindings behind an `isManagerReady` boolean that never resets while mounted. The manager captures the native view once in its initializer (`weak var view` on iOS), so after the native view is deallocated and recreated, the second `onNitroIdChange` was silently ignored: the stale manager pointed at a dead view and `manager.player = …` was never re-applied, leaving the fresh native view with no player and no rendering.

This PR treats every `onNitroIdChange` as a new **native view generation**:

- always recreate the view manager (the previous one wraps the deallocated view),
- replace `isManagerReady: boolean` with a `managerGeneration: number` state,
- key the listener-registration and `updateProps` effects on the generation so `player`, `controls`, `resizeMode`, etc. are re-applied to the recreated view.

No behavior change in the steady state: for a view that is created exactly once, the flow is identical to before (one manager, one generation bump).

## Test plan

Reproduced and verified in an RN 0.81 / Expo 54 app (New Architecture, iOS 26 simulator):

- Home screen with 6 inline `VideoView`s → push a fullscreen screen on a native stack → pop.
- Before: all 6 inline views come back black (native logs show recreated views with no player and no `AVPlayerViewController`, and no rebinding).
- After: every surviving component logs a fresh view-manager setup at pop and all views render and resume playback. Verified across repeated push/pop cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
