### PR TITLE
fix(ios): make player release idempotent and replace player items on the main thread

### DIFF
--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -32,6 +32,8 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
   }
   var playerObserver: VideoPlayerObserver?
   private let sourceLoader = SourceLoader()
+  private let releaseLock = NSLock()
+  private var hasReleased = false
 
   init(source: (any HybridVideoPlayerSourceSpec)) throws {
     self.source = source
@@ -50,7 +52,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
           self.playerItem = try await self.sourceLoader.load {
             try await self.initializePlayerItem()
           }
-          self.player.replaceCurrentItem(with: self.playerItem)
+          await self.replaceCurrentItemOnMain(with: self.playerItem)
         } catch {
           // Ignore cancellation errors during initialization
         }
@@ -203,7 +205,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
         self.playerItem = try await self.sourceLoader.load {
           try await self.initializePlayerItem()
         }
-        self.player.replaceCurrentItem(with: self.playerItem)
+        await self.replaceCurrentItemOnMain(with: self.playerItem)
       } catch {
         if error is CancellationError {
           throw PlayerError.cancelled.error()
@@ -213,7 +215,45 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
     }
   }
 
+  private func claimRelease() -> Bool {
+    releaseLock.lock()
+    defer { releaseLock.unlock() }
+
+    if hasReleased {
+      return false
+    }
+
+    hasReleased = true
+    return true
+  }
+
+  private func replaceCurrentItemOnMain(with playerItem: AVPlayerItem?) async {
+    let player = self.player
+    await MainActor.run {
+      player.replaceCurrentItem(with: playerItem)
+    }
+  }
+
+  private func removeCurrentItemForRelease() {
+    let player = self.player
+    let removeCurrentItem = {
+      player.pause()
+      player.replaceCurrentItem(with: nil)
+    }
+
+    if Thread.isMainThread {
+      removeCurrentItem()
+      return
+    }
+
+    DispatchQueue.main.async(execute: removeCurrentItem)
+  }
+
   func release() {
+    guard claimRelease() else {
+      return
+    }
+
     sourceLoader.cancelSync()
     NowPlayingInfoCenterManager.shared.removePlayer(player: player)
 
@@ -230,7 +270,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
     playerObserver?.invalidatePlayerObservers()
     self.playerObserver = nil
 
-    self.player.replaceCurrentItem(with: nil)
+    removeCurrentItemForRelease()
     status = .idle
 
     VideoManager.shared.unregister(player: self)
@@ -259,7 +299,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
         }
         self.playerItem = playerItem
 
-        self.player.replaceCurrentItem(with: playerItem)
+        await self.replaceCurrentItemOnMain(with: playerItem)
         promise.resolve(withResult: ())
       } catch {
         if error is CancellationError {
@@ -352,7 +392,7 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
           self.playerItem = try await self.sourceLoader.load {
             try await self.initializePlayerItem()
           }
-          self.player.replaceCurrentItem(with: self.playerItem)
+          await self.replaceCurrentItemOnMain(with: self.playerItem)
           promise.resolve(withResult: ())
         } catch {
           if error is CancellationError {


### PR DESCRIPTION
## Summary

Two related lifecycle hardenings for `HybridVideoPlayer` on iOS that we have been running in production (via a local patch) since 7.0.0-beta.9:

1. **Make `release()` idempotent.** `release()` is reachable from three paths — `deinit`, `dispose()`, and `replaceSourceAsync(nil)` — and nothing prevents it from running twice (e.g. an explicit dispose followed by `deinit`). A second pass re-walks teardown (`NowPlayingInfoCenterManager.removePlayer`, observer invalidation, `VideoManager.unregister`) against already-torn-down state. This PR adds an `NSLock`-guarded `claimRelease()` so only the first caller performs teardown.

2. **Call `AVPlayer.replaceCurrentItem(with:)` on the main thread.** Several call sites invoke it from detached/background tasks (`preload()` and `replaceSourceAsync` use `Task.detached(priority: .userInitiated)`; `init` and `initialize()` run in unstructured `Task`s), and `release()` can be reached from `deinit` on an arbitrary thread. AVFoundation expects mutations of the player's item to happen on the main thread; off-main calls intermittently produce KVO/teardown races. All five call sites now hop to the main actor (`replaceCurrentItemOnMain`), and release uses a fire-and-forget main-queue dispatch (`removeCurrentItemForRelease`) since `deinit` cannot await.

## Test plan

- Running in a production feed app (RN 0.81, New Architecture) with heavy player churn — dozens of created/preloaded/destroyed players per session across an inline autoplay carousel and a fullscreen pager (FlashList recycling) — since beta.9, with no regressions and no more shutdown races.
- Steady-state behavior unchanged: single release path performs the exact same teardown as before, item replacement is just serialized onto the main thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
