### PR TITLE
docs: add "Build with AI" category (Overview, llms.txt, Skills)

### DIFF
--- a/docs/docs/build-with-ai/_category_.json
+++ b/docs/docs/build-with-ai/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Build with AI",
+  "position": 2,
+  "collapsed": false,
+  "customProps": {
+    "badgeType": "new"
+  }
+}

--- a/docs/docs/build-with-ai/llms-txt.mdx
+++ b/docs/docs/build-with-ai/llms-txt.mdx
@@ -1,0 +1,60 @@
+---
+title: llms.txt
+sidebar_label: llms.txt
+sidebar_position: 2
+description: The llms.txt files react-native-video publishes for AI coding agents. How Cursor, Claude Code, Copilot and Context7 actually use them (URL-based, no copy-paste), plus every file and when to reach for it.
+keywords: [llms.txt, llms-full.txt, AI coding agent, Cursor, Claude Code, Context7, MCP, react native video]
+---
+
+# llms.txt
+
+[`llms.txt`](https://llmstxt.org) is a standard for exposing documentation to AI in a clean, plain-text form: a curated index of the docs (titles, links, descriptions) plus a full-text bundle. Think `robots.txt`, but for LLMs.
+
+We generate these on **every build**, so they always match the current docs.
+
+The main file (current v7 docs):
+
+```
+https://docs.thewidlarzgroup.com/react-native-video/llms.txt
+```
+
+Full-text and version-specific variants are in [Files we publish](#files-we-publish) below.
+
+## How it's actually used
+
+Not by pasting it into a chat. In practice llms.txt is a **Business-to-Agent** format, and the real consumers are **coding agents**:
+
+- **Your coding agent fetches it on demand.** Point Cursor, Claude Code, GitHub Copilot, Windsurf, Cline, or Aider at the URL (via Cursor's **@Docs**, or by listing it in a rules file like `.cursor/rules/…`, `CLAUDE.md`, or `AGENTS.md`), and the agent pulls `llms.txt` when it's relevant and follows the links it needs. It's URL-based: no copy-paste, no token bloat.
+- **Context7 (MCP) already has our docs.** react-native-video is indexed on [Context7](https://context7.com), including the v7 documentation. With the Context7 MCP configured, just add **`use context7`** to your prompt and your assistant gets up-to-date, version-specific react-native-video docs injected automatically, so you never touch a `.txt` file.
+- **The skill is the turnkey version.** [Install the skill](./skills.mdx) and you get all of the above wrapped with automatic version detection. Nothing to wire up.
+- **Plain chat? Paste as a fallback.** In a chat that can't fetch URLs (a basic ChatGPT/Claude window), paste `llms-full.txt`. Note: general web-crawling models don't reliably auto-load llms.txt, so treat this as a fallback, not the main path.
+
+:::note Honest take
+IDE and coding agents use llms.txt today; the big web-search LLMs mostly don't yet, and it isn't an SEO trick. We publish it for the coding-agent workflow above.
+:::
+
+## Files we publish
+
+Served from the docs root. **Point your agent at `llms.txt`**; the rest are variants for specific needs.
+
+| File | What it is |
+|------|-----------|
+| [`llms.txt`](https://docs.thewidlarzgroup.com/react-native-video/llms.txt) | **The one to link.** Curated index of the current (v7) docs (titles, descriptions, links); the generated API reference is left out for signal. |
+| [`llms-full.txt`](https://docs.thewidlarzgroup.com/react-native-video/llms-full.txt) | The same curated docs as **one full-text file** for a single paste into a large-context chat. |
+| [`llms-v7.txt`](https://docs.thewidlarzgroup.com/react-native-video/llms-v7.txt) / [`llms-v7-full.txt`](https://docs.thewidlarzgroup.com/react-native-video/llms-v7-full.txt) | v7 **including the full API reference** (bigger and noisier; use when you need exact TypeScript signatures). |
+| [`llms-v6.txt`](https://docs.thewidlarzgroup.com/react-native-video/llms-v6.txt) / [`llms-v6-full.txt`](https://docs.thewidlarzgroup.com/react-native-video/llms-v6-full.txt) | Legacy v6 index / full text. |
+
+## Set it up
+
+- **Cursor** - add the URL to Cursor's indexed docs (**Settings → Indexing & Docs**, or `@Docs → Add new doc` in the chat; see [Cursor's docs](https://cursor.com/docs/context/@-symbols/@-docs)), or list it in a `.cursor/rules/*.md` file.
+- **Claude Code / Codex** - add the URL to `CLAUDE.md` / `AGENTS.md`, or just [install the skill](./skills.mdx).
+- **Copilot / Windsurf / Cline / Aider** - reference the URL in the tool's rules or context file.
+- **Context7** - with the MCP set up, add `use context7` to your prompt; it resolves react-native-video automatically.
+- **Plain chat (fallback)** - paste `llms-full.txt`.
+
+## Which file?
+
+- **Link one URL:** `llms.txt` (current v7, curated).
+- **Need exact API signatures:** `llms-v7.txt` / `llms-v7-full.txt`.
+- **App is on v6:** `llms-v6.txt` / `llms-v6-full.txt`. (Check `package.json` → `react-native-video`: `7.x` incl. `7.0.0-beta.x` is v7; `6.x` is v6.)
+- **Want zero setup:** [install the skill](./skills.mdx), with version detection and routing built in.

--- a/docs/docs/build-with-ai/overview.mdx
+++ b/docs/docs/build-with-ai/overview.mdx
@@ -1,0 +1,93 @@
+---
+title: Build with AI
+sidebar_label: Overview
+sidebar_position: 1
+description: Use AI assistants like Claude Code, Cursor, and ChatGPT to build with react-native-video. Install the agent skill in one command, point tools at llms.txt, and give your assistant version-aware (v6/v7) context.
+keywords: [react native video, AI, LLM, llms.txt, Claude Code, Cursor, agent skill, AI assistant, Codex]
+---
+
+# Build with AI
+
+AI assistants are great at React Native, right up until they guess at react-native-video. The library has **two very different APIs** (v6's `<Video>` component and v7's `useVideoPlayer` + `VideoView` player model), and an assistant with no context will happily mix them, invent props, or reach for a `drm` prop that only exists in one of them.
+
+The fix is simple: **give your assistant the right context.** This page shows the three ways to do that, from "drop-in for agents" to "paste into a chat," and points you to the deep-dive pages.
+
+## Give your AI context
+
+Pick the option that matches your tool. You can combine them.
+
+### 1. Install the skill (best for coding agents)
+
+Our agent skill teaches the assistant to detect your installed version first, then use the matching API, plus DRM, offline, PiP, background audio, native setup, and v6→v7 migration. **One command installs it for every agent you use** (Claude Code, Cursor, Codex, Copilot, Windsurf, Gemini, VS Code, and dozens more):
+
+```sh
+npx skills add TheWidlarzGroup/react-native-video
+```
+
+No per-tool config. The [skills.sh](https://skills.sh) CLI writes the skill into each agent's directory for you.
+
+→ Full details on the **[Skills](./skills.mdx)** page.
+
+### 2. Point your coding agent at `llms.txt` (or Context7)
+
+This is how llms.txt is actually used: give the URL to your agent and it fetches on demand. Add it to Cursor's **@Docs**, or list it in a rules file (`.cursor/rules/…`, `CLAUDE.md`) for Claude Code, Copilot, Windsurf, Cline, or Aider. It's all URL-based, so no copy-paste and no token bloat.
+
+```
+https://docs.thewidlarzgroup.com/react-native-video/llms.txt
+```
+
+Already using **[Context7](https://context7.com)**? react-native-video is indexed there, so just add `use context7` to your prompt and up-to-date docs are injected automatically.
+
+→ Every file and how to wire it up on the **[llms.txt](./llms-txt.mdx)** page.
+
+### 3. Paste the docs (quick fallback for plain chat)
+
+No integration? In a plain ChatGPT, Claude, or Gemini window, paste a `llms.txt` file before you ask your question. Fastest way to unblock a one-off.
+
+## Set up your tool
+
+**Claude Code** - Install the skill (option 1); it activates automatically when your prompt mentions react-native-video, `useVideoPlayer`, `VideoView`, and friends. To pin context for a whole project, add the `llms.txt` URL to your `CLAUDE.md`.
+
+**Cursor** - Install the skill (option 1), or add the `llms.txt` URL to Cursor's indexed docs (**Settings → Indexing & Docs**, or `@Docs → Add new doc` in the chat; the exact spot moves between versions, so see [Cursor's docs](https://cursor.com/docs/context/@-symbols/@-docs)). Version-proof alternative: list the URL in a `.cursor/rules/*.md` file.
+
+**Context7 (MCP)** - Add `use context7` to your prompt. react-native-video is already indexed, so current, version-specific docs are injected automatically.
+
+**ChatGPT / Claude.ai / Gemini** - The fallback for plain chat: paste a `llms.txt` file (option 3). For a persistent setup, add the `llms.txt` URL to a Project's custom instructions or knowledge.
+
+**Codex, Copilot, Windsurf, Gemini, VS Code, and more** - Install the skill (option 1). The same `npx skills add` command sets it up for each. One command covers dozens of agents.
+
+**Anything else** - Reference the `llms.txt` URL in whatever context or rules file your tool supports.
+
+## Why version context matters
+
+react-native-video v6 and v7 are **not** the same API:
+
+- **v6**: one imperative component (`<Video source paused ... />`), controlled through props and a `ref`.
+- **v7**: a player object (`const player = useVideoPlayer(source)`) rendered with `<VideoView player={player} />`, controlled through the player instance.
+
+An assistant that doesn't know which one you're on will produce code that simply doesn't exist in your version. The skill solves this by detecting your version first; the `llms.txt` files are version-labelled so you can point the assistant at exactly v6 or v7. When in doubt, tell your assistant which major version you use.
+
+## Example prompts
+
+With the skill installed (or `llms.txt` loaded), paste any of these to get going:
+
+```text
+Build a video player screen with react-native-video v7 (useVideoPlayer + VideoView)
+that plays an HLS stream, shows native controls, and pauses when the screen loses focus.
+```
+
+```text
+Migrate this v6 <Video> component to the v7 useVideoPlayer + VideoView API.
+```
+
+```text
+Add Picture-in-Picture and fullscreen support to my VideoView in react-native-video v7.
+```
+
+```text
+Set up Widevine (Android) and FairPlay (iOS) DRM playback with react-native-video v7.
+```
+
+## What's next
+
+We're exploring more ways to make react-native-video first-class for AI workflows, starting with an **MCP server**. Have a request, or a setup that works well for you? Tell us in **[GitHub Discussions](https://github.com/TheWidlarzGroup/react-native-video/discussions)**.

--- a/docs/docs/build-with-ai/skills.mdx
+++ b/docs/docs/build-with-ai/skills.mdx
@@ -1,0 +1,57 @@
+---
+title: Skills
+sidebar_label: Skills
+sidebar_position: 3
+description: Install the react-native-video agent skill with one command (npx skills add) for Claude Code, Cursor, Codex, and dozens more AI agents. Version-aware, source-verified guidance for v6 and v7.
+keywords: [agent skill, skills.sh, Claude Code, Cursor, Codex, AI, react native video, Copilot]
+---
+
+# Skills
+
+An **agent skill** is a reusable instruction set: a `SKILL.md` file your AI assistant loads automatically when it's relevant. Ours teaches your assistant to use react-native-video *correctly*, across **both v6 and v7**.
+
+`SKILL.md` is an open standard supported natively by Claude Code, Codex, Cursor, GitHub Copilot, and VS Code, among others. Ours is distributed through [skills.sh](https://skills.sh), Vercel Labs' open skills registry, so **one command installs it into every agent you have**, no per-tool setup.
+
+## Install
+
+```sh
+npx skills add TheWidlarzGroup/react-native-video
+```
+
+That's the whole setup. The `npx skills` CLI **auto-detects the coding agents on your machine** and writes the skill into each one's skills directory (`.claude/skills/`, `.cursor/`, and so on). If it can't detect any, it asks which to install to. No config, no API keys, no pasting into rules files.
+
+## What it does
+
+### Detects your version first
+
+The most common AI mistake with this library is mixing v6 and v7. The skill checks your installed version **before** giving any API advice, then uses the matching model, never handing a v7 user a `<Video source>` example or telling a v6 user to call `useVideoPlayer`.
+
+### Activates on
+
+Playing or controlling video/audio, the v6 `Video` component or the v7 `useVideoPlayer` / `VideoView` API, source / props / events (`onLoad`, `onProgress`, `onEnd`, `paused`, `resizeMode`, `drm`), HLS/DASH, DRM (Widevine / FairPlay, `@react-native-video/drm`), captions & tracks, Picture-in-Picture, background / lockscreen audio, fullscreen, buffering, offline / downloading, native iOS/Android setup, and deciding between v6 and v7 or migrating between them.
+
+Trigger words include `react-native-video`, `RNV`, `Video`, `useVideoPlayer`, `VideoView`.
+
+### Covers
+
+- **Version choice & migration** - an honest v6-vs-v7 decision guide and a v6→v7 migration path.
+- **Correct API per version** - component model (v6) vs player model (v7): setup, playback control, events.
+- **Hard topics** - DRM, tracks/subtitles, PiP, fullscreen, background audio, offline, video feeds.
+- **Native setup & troubleshooting** - install, streaming, background modes, and a troubleshooting reference.
+
+### Output you can trust
+
+API claims are **verified against the library source and docs**, not guessed. The skill presents v7's beta status honestly (it's beta, but ships in production apps with 1M+ users) and points to TheWidlarzGroup add-ons only when the open-source core genuinely can't do the job, helpfully and never salesy.
+
+## Compatibility
+
+The same `npx skills add` command works across the open skills ecosystem, covering **dozens of agents**, including:
+
+Claude Code · Cursor · Codex · GitHub Copilot · Windsurf · Gemini CLI · Amp · Antigravity · Goose · Kilo · Kiro CLI · OpenCode · Roo · Trae · Droid · VS Code, and many more.
+
+If your agent supports the `SKILL.md` standard, this skill works in it.
+
+## Learn more
+
+- Skill source & `SKILL.md`: [`skills/react-native-video`](https://github.com/TheWidlarzGroup/react-native-video/tree/master/skills/react-native-video)
+- Prefer plain context instead of a skill? See **[llms.txt](./llms-txt.mdx)**.

--- a/docs/docs/fundamentals/intro.mdx
+++ b/docs/docs/fundamentals/intro.mdx
@@ -3,9 +3,7 @@ title: Introduction to React Native Video
 sidebar_label: Intro
 sidebar_position: 1
 description: React Native Video v7 overview — new Player API, Nitro Modules foundation, plugin architecture, and DRM support for iOS, Android, and tvOS.
-keywords: [react native video, video player, Nitro Modules, v7, cross-platform, iOS, Android, tvOS]
-customProps:
-  badgeType: new
+keywords: [react native video, video player, Nitro Modules, v7, cross-platform, iOS, Android, tvOS, AI, llms.txt, agent skill, Claude Code, Cursor]
 ---
 
 import {
@@ -23,6 +21,10 @@ import {
 <V7Lead />
 
 React Native Video is a powerful, cross-platform video player library for React Native. Version 7 introduces a new Player API built on Nitro Modules for type-safe, high-performance native communication. It supports DRM protection (Widevine and FairPlay), a modular plugin architecture, offline video playback, and works on iOS, Android, tvOS, and visionOS with both New and Old Architecture.
+
+:::tip Building with an AI assistant?
+Install the **[react-native-video skill](../build-with-ai/skills.mdx)**: one command (`npx skills add TheWidlarzGroup/react-native-video`) sets up Claude Code, Cursor, Codex and more to write correct, version-aware code. See **[Build with AI](../build-with-ai/overview.mdx)** for other options.
+:::
 
 ## What changed in v7 vs v6
 

--- a/docs/docs/player/_category_.json
+++ b/docs/docs/player/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Player",
-  "position": 2,
+  "position": 3,
   "collapsed": false
 }

--- a/docs/docs/plugins/_category_.json
+++ b/docs/docs/plugins/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Plugins",
-  "position": 4,
+  "position": 5,
   "collapsed": false
 }

--- a/docs/docs/updating.md
+++ b/docs/docs/updating.md
@@ -1,9 +1,9 @@
 ---
 title: Migration Guide — Upgrading from v6 to v7
 sidebar_label: Updating
-description: React Native Video Updating Guide
+description: Upgrade React Native Video from v6 to v7 — moving from the imperative Video component to the useVideoPlayer + VideoView player model, with a step-by-step guide and tips for migrating faster with an AI assistant.
 sidebar_class_name: hidden
-keywords: [updating, migration, upgrade guide, breaking changes, react native video]
+keywords: [updating, migration, upgrade guide, breaking changes, v6 to v7, AI migration, Claude Code, Cursor, agent skill, react native video]
 ---
 
 # Updating
@@ -11,6 +11,10 @@ keywords: [updating, migration, upgrade guide, breaking changes, react native vi
 ## Upgrading from react-native-video v6 to v7
 
 Version 7 of `react-native-video` introduces a significant architectural shift, separating the video player logic from the UI rendering. This change unlocks new capabilities like video preloading and a more intuitive, hook-based API. This guide will walk you through the necessary steps to migrate your application from v6 to v7.
+
+:::tip Migrate faster with an AI assistant
+Our agent skill knows the v6→v7 mapping. Install it with `npx skills add TheWidlarzGroup/react-native-video` and let your editor rewrite `Video` calls into the `useVideoPlayer` + `VideoView` model. See [Build with AI](./build-with-ai/overview.mdx).
+:::
 
 ### Key Changes in v7
 

--- a/docs/docs/video-view/_category_.json
+++ b/docs/docs/video-view/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "video-view",
-  "position": 3,
+  "position": 4,
   "collapsed": false
 }


### PR DESCRIPTION
## What

Adds a new **Build with AI** docs category (placed second, right after Fundamentals) on using AI assistants with react-native-video. Three tabs:

- **Overview** — give your AI context (skill / llms.txt / Context7 / paste), per-tool setup (Claude Code, Cursor, Context7, ChatGPT…), the v6-vs-v7 gotcha, and copy-paste example prompts.
- **llms.txt** — the `llms*.txt` files we already publish, how coding agents actually consume them (URL-based fetch, Context7 — not manual paste), and which file to pick.
- **Skills** — the `react-native-video` agent skill, one-command install via skills.sh (`npx skills add TheWidlarzGroup/react-native-video`) across dozens of agents.

## Why

The v6/v7 API split is the biggest source of AI hallucination for this library. This category points developers (and their agents) at the right, version-aware context.

## Notes

- The `new` badge is on the category only, not the individual tabs.
- Cross-links the **Intro** and **Migration guide** pages to the new category.
- Content reflects how llms.txt and agent skills are actually used in 2026 (coding agents fetch URLs / Context7; skills.sh installs one `SKILL.md` into every agent), verified against the tools' own docs.
- Renumbers existing category positions so Build with AI sits second.
- `docs/` builds clean (`bun run build`, no broken links).
