### PR TITLE
fix(android): implement updateSurfaceView for viewType switching

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.kt
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
+import android.view.SurfaceView
+import android.view.TextureView
 import android.view.View
 import android.view.View.MeasureSpec
 import android.widget.FrameLayout
@@ -17,6 +19,7 @@ import androidx.media3.ui.DefaultTimeBar
 import androidx.media3.ui.PlayerView
 import com.brentvatne.common.api.ResizeMode
 import com.brentvatne.common.api.SubtitleStyle
+import com.brentvatne.common.api.ViewType as RNVViewType
 
 @UnstableApi
 class ExoPlayerView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) :
@@ -24,6 +27,7 @@ class ExoPlayerView @JvmOverloads constructor(context: Context, attrs: Attribute
 
     private var localStyle = SubtitleStyle()
     private var pendingResizeMode: Int? = null
+    private var appliedSurfaceViewType: Int? = null
     private val liveBadge: TextView = TextView(context).apply {
         text = "LIVE"
         setTextColor(Color.WHITE)
@@ -140,7 +144,52 @@ class ExoPlayerView @JvmOverloads constructor(context: Context, attrs: Attribute
     }
 
     fun updateSurfaceView(viewType: Int) {
-        // TODO: Implement proper surface type switching if needed
+        if (appliedSurfaceViewType == viewType) {
+            return
+        }
+
+        val currentSurfaceView = playerView.videoSurfaceView ?: return
+        val shouldUseTextureView = viewType == RNVViewType.VIEW_TYPE_TEXTURE
+        val isCurrentTextureView = currentSurfaceView is TextureView
+
+        if (shouldUseTextureView == isCurrentTextureView) {
+            if (!shouldUseTextureView && currentSurfaceView is SurfaceView) {
+                currentSurfaceView.setSecure(viewType == RNVViewType.VIEW_TYPE_SURFACE_SECURE)
+            }
+            appliedSurfaceViewType = viewType
+            return
+        }
+
+        val contentFrame =
+            playerView.findViewById<AspectRatioFrameLayout>(androidx.media3.ui.R.id.exo_content_frame)
+                ?: return
+        val replacementSurfaceView: View = if (shouldUseTextureView) {
+            TextureView(context).apply {
+                isOpaque = false
+            }
+        } else {
+            SurfaceView(context).apply {
+                if (viewType == RNVViewType.VIEW_TYPE_SURFACE_SECURE) {
+                    setSecure(true)
+                }
+            }
+        }
+        val insertIndex = contentFrame.indexOfChild(currentSurfaceView).coerceAtLeast(0)
+        val player = playerView.player
+
+        clearVideoSurface(player, currentSurfaceView)
+        contentFrame.removeView(currentSurfaceView)
+        replacementSurfaceView.layoutParams = FrameLayout.LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            LayoutParams.MATCH_PARENT,
+        )
+        contentFrame.addView(replacementSurfaceView, insertIndex)
+        setInternalSurfaceViewField(replacementSurfaceView)
+        attachVideoSurface(player, replacementSurfaceView)
+
+        appliedSurfaceViewType = viewType
+        playerView.requestLayout()
+        requestLayout()
     }
 
     val isPlaying: Boolean
@@ -254,6 +303,28 @@ class ExoPlayerView @JvmOverloads constructor(context: Context, attrs: Attribute
 
     companion object {
         private const val TAG = "ExoPlayerView"
+    }
+
+    private fun clearVideoSurface(player: Player?, surfaceView: View) {
+        when (surfaceView) {
+            is TextureView -> player?.clearVideoTextureView(surfaceView)
+            is SurfaceView -> player?.clearVideoSurfaceView(surfaceView)
+        }
+    }
+
+    private fun attachVideoSurface(player: Player?, surfaceView: View) {
+        when (surfaceView) {
+            is TextureView -> player?.setVideoTextureView(surfaceView)
+            is SurfaceView -> player?.setVideoSurfaceView(surfaceView)
+        }
+    }
+
+    private fun setInternalSurfaceViewField(surfaceView: View) {
+        runCatching {
+            val surfaceField = PlayerView::class.java.getDeclaredField("surfaceView")
+            surfaceField.isAccessible = true
+            surfaceField.set(playerView, surfaceView)
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Implements `ExoPlayerView.updateSurfaceView()` on the v6 Android path so the documented `viewType` prop actually switches between `TextureView` and `SurfaceView` inside media3 `PlayerView`.

Fixes #5024.

## Motivation

Since the media3 `PlayerView` migration (#4581), `ExoPlayerView.updateSurfaceView()` has been a TODO stub on the v6 maintenance line. The native bridge still receives `viewType` from JS (`ReactExoplayerViewManager` → `ReactExoplayerView.setViewType`), but no surface swap happens.

This breaks a documented Android use case: **`viewType="texture"` is required for video to respect parent clipping** (`borderRadius`, `overflow: 'hidden'`). Without TextureView, video renders on the default `SurfaceView` and:

- Rounded inline preview cards do not clip video corners correctly
- Video can bleed across neighboring list cells (e.g. FlashList inline autoplay feeds)

Surface switching worked before v6.16.0. #4594 removed a partial hybrid implementation and left the stub. v7 already addressed this with the new `surfaceType` prop and `VideoView.kt` layout recreation (#4719), but v6 users on `support/6.x.x` still hit the regression.

## Changes

- Implement real `TextureView` / `SurfaceView` swapping inside `exo_content_frame`
- Track `appliedSurfaceViewType` to avoid redundant swaps
- Clear and reattach the ExoPlayer video surface during swap
- Sync media3 `PlayerView`'s internal `surfaceView` field via reflection (required because v6 keeps a single programmatic `PlayerView` instance, unlike v7's layout recreation approach)
- Restore pre-regression behavior details:
  - `TextureView.isOpaque = false` for proper opacity/clipping
  - `SurfaceView.setSecure(true)` when `viewType` is `VIEW_TYPE_SURFACE_SECURE`

**Files changed:** `android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.kt` only.

## Platforms affected

- [x] Android
- [ ] iOS
- [ ] visionOS
- [ ] tvOS / Android TV
- [ ] Windows
- [ ] Web

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only

## Test plan

Manual verification on Android (example app or consumer app):

1. Render `<Video viewType="texture" ... />` inside a container with `borderRadius` and `overflow: 'hidden'`.
2. Play video and confirm corners are clipped to the rounded bounds.
3. Toggle `viewType` between `texture` and `surface` at runtime and confirm playback continues on the new surface.
4. (Optional) Verify `viewType="secureView"` sets the secure flag on `SurfaceView`.
5. (Optional) In a FlashList with multiple inline autoplay videos, confirm neighboring cells no longer show video bleed.

No JS/API changes — this restores documented `viewType` behavior, so no docs or skill updates are needed.

## Checklist

- [x] I read the [contributing guidelines](https://github.com/TheWidlarzGroup/react-native-video/blob/master/CONTRIBUTING.md).
- [x] This PR is focused on a single concern.
- [x] No public API / docs changes (behavior restoration only).
- [ ] I tested my changes on at least one platform. *(Maintainers: please verify on Android device/emulator.)*

Made with [Cursor](https://cursor.com)