### PR TITLE
fix(ios): start playback immediately instead of waiting for the stall heuristic

### DIFF
--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -274,7 +274,18 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
   }
 
   func play() throws {
-    player.play()
+    // `AVPlayer.play()` defers actual playback until the
+    // `isPlaybackLikelyToKeepUp` heuristic clears, which parks cold HLS starts
+    // at rate 0 for over a second (play() issued, currentTime frozen at 0.00).
+    // `playImmediately(atRate:)` starts with whatever is already buffered
+    // while keeping `automaticallyWaitsToMinimizeStalling` enabled, so
+    // AVFoundation still waits-and-resumes by itself on mid-playback
+    // buffer underruns.
+    if #available(iOS 16.0, tvOS 16.0, *) {
+      player.playImmediately(atRate: player.defaultRate)
+    } else {
+      player.playImmediately(atRate: 1.0)
+    }
   }
 
   func pause() throws {


### PR DESCRIPTION
## Summary

`play()` currently calls `AVPlayer.play()`, which (with the default `automaticallyWaitsToMinimizeStalling = true`) defers actual playback until AVFoundation's `isPlaybackLikelyToKeepUp` heuristic clears. On cold HLS starts this parks the player at rate 0 for a long time: in our app (short-form vertical video feed, Mux HLS, iPhone 13 / iOS 26) we consistently measured **~1.6s between `play()` and playback actually engaging** — `play()` issued, `currentTime` frozen at 0.00, `readyToPlay` arriving +1622ms later. The user sees a frozen first frame (or poster) while audio/clock go nowhere.

This PR changes `play()` to `playImmediately(atRate:)`, which starts playback with whatever is already buffered. After the change the same entries engage in **~150ms**.

## Why not `automaticallyWaitsToMinimizeStalling = false`

We tried that first and it's a trap: with the flag off, AVPlayer does **not** automatically resume after a mid-playback buffer underrun, and the library has no `AVPlayerItemPlaybackStalled` handling — a stalled player just freezes until the app intervenes. `playImmediately(atRate:)` only overrides the *initial* wait; `automaticallyWaitsToMinimizeStalling` stays enabled, so later stalls still wait-and-resume by themselves. This is the combination Apple documents for exactly this use case.

`playImmediately(atRate:)` is available since iOS 10 / tvOS 10. `defaultRate` needs iOS 16, hence the availability check (falls back to rate 1.0, which matches what `play()` effectively did).

## Notes / open question

- If you'd rather not change the default semantics for everyone, I'm happy to rework this as an opt-in (e.g. a `startPolicy: 'immediate' | 'automatic'` on the source or player config) — let me know which shape you'd prefer. For feed-style apps the immediate start is a large UX win; for long-form content some apps may prefer the conservative pre-buffer.
- Validated in a production app on device (iPhone 13, iOS 26.5, HLS): cold-start engage time 1622ms → ~150ms across repeated entries; mid-playback stalls on throttled networks recover automatically as before.
- Android is unaffected (ExoPlayer path).

## Test plan

- Cold-start an HLS source and observe time between `play()` and `currentTime` advancing (was ~1.6s, now ~150ms).
- Throttle the network mid-playback until the buffer drains: playback pauses and resumes automatically (stall recovery intact).
- Regular play/pause/seek flows unchanged.
