### PR TITLE
fix(android): fixes selectedTextTrack type 'index' only ever matching the first track

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2141,10 +2141,15 @@ public class ReactExoplayerView extends FrameLayout implements
                 if (textRendererIndex != C.INDEX_UNSET) {
                     TrackGroupArray groups = info.getTrackGroups(textRendererIndex);
                     boolean trackFound = false;
+                    // "index" counts the way getTextTrackInfo numbers the tracks reported
+                    // to JS: a flat position across all groups and their tracks. Comparing
+                    // against trackIndex (the position inside a group) only ever matched 0,
+                    // because text tracks are typically one group per track.
+                    int flatIndex = 0;
                     
                     for (int groupIndex = 0; groupIndex < groups.length; groupIndex++) {
                         TrackGroup group = groups.get(groupIndex);
-                        for (int trackIndex = 0; trackIndex < group.length; trackIndex++) {
+                        for (int trackIndex = 0; trackIndex < group.length; trackIndex++, flatIndex++) {
                             Format format = group.getFormat(trackIndex);
                             
                             boolean isMatch = false;
@@ -2154,7 +2159,7 @@ public class ReactExoplayerView extends FrameLayout implements
                                 isMatch = true;
                             } else if ("index".equals(type)) {
                                 int targetIndex = ReactBridgeUtils.safeParseInt(value, -1);
-                                if (targetIndex == trackIndex) {
+                                if (targetIndex == flatIndex) {
                                     isMatch = true;
                                 }
                             }


### PR DESCRIPTION
## Summary

On Android, `selectedTextTrack={{type: 'index', value: N}}` is a silent no-op for any `N >= 1` (regression in 6.16.0, introduced by #4581 — verified via `git log -S`: the comparison first appears in that PR's commit, and `v6.16.0` is the first tag containing it).

`selectTextTrackInternal` compares the requested index against `trackIndex`, the position *inside* each track group. Text tracks are typically mapped as one single-track group each, so `trackIndex` is `0` for every group: only index 0 can ever match. Selecting any other index clears existing overrides, logs `Text track not found for type=index … Keeping current selection`, and applies nothing. If the stream has a default-flagged text track, it keeps rendering, which makes the failed selection easy to miss.

Meanwhile `getTextTrackInfo` numbers the tracks it reports through `onTextTracks` with a flat running position across all groups — so the index a JS app reads from `onTextTracks` and feeds back into `selectedTextTrack` never referred to the same track the selection side was looking for. (Before #4581, index selection resolved a track-group index, which matches the reported numbering for the common one-track-per-group mapping.)

## Changes

Count a flat position across all groups and their tracks in `selectTextTrackInternal`, and match `"index"` against it — the same numbering `getTextTrackInfo` reports to JS. `language` and `title` matching are untouched.

## Test plan

Any stream with 2+ text tracks reproduces it. A convenient source is [fakestream](https://github.com/ektotv/fakestream), which generates synthetic test streams: `fakestream serve`, then play `http://localhost:8080/vod/multilingual.mkv` (four SubRip tracks: eng, fra, spa, jpn, each cue prefixed `[EN]`/`[FR]`/`[ES]`/`[JA]` so the active track is visible at a glance). On a device or emulator, bridge the port first with `adb reverse tcp:8080 tcp:8080`, and use cleartext-permitted debug builds since the URL is plain http.

- Before: `{type: 'index', value: 1}` leaves the previous track rendering (or the default-flagged track), with `Text track not found … Keeping current selection` in logcat
- After: indexes 0–3 each select and render their track; `selected` in `onTextTracks` follows
- `{type: 'disabled'}` and `{type: 'language'}` behave as before
