### PR TITLE
fix(ios): remove unused RCTEventDispatcher import from paper view manager

### DIFF
--- a/packages/react-native-video/ios/view/paper/RCTVideoViewViewManager.m
+++ b/packages/react-native-video/ios/view/paper/RCTVideoViewViewManager.m
@@ -1,5 +1,4 @@
 #import <React/RCTViewManager.h>
-#import "RCTEventDispatcher.h"
 #import "RCTVideoViewComponentView.h"
 
 @interface RCTVideoViewViewManager : RCTViewManager


### PR DESCRIPTION
## Summary

`ios/view/paper/RCTVideoViewViewManager.m` contains an unused `#import "RCTEventDispatcher.h"` — nothing in the file references the class.

That header belongs to **`React-CoreModules`**, which is not a declared dependency of `ReactNativeVideo.podspec`. The import currently resolves only because header search paths leak from other pods under static linkage; under `use_frameworks!` it can fail to resolve and break the build of the paper (old architecture) target.

Since the import is dead code, this PR simply removes it.

## Context

This is the v7 sibling of the same latent issue fixed on `support/6.x.x` (see #5033), where the concrete `RCTEventDispatcher` class was actually referenced and produced `Undefined symbols: _OBJC_CLASS_$_RCTEventDispatcher` under `use_frameworks! :linkage => :dynamic`. The v7 rewrite no longer uses the class at all — this stray import was the only remaining trace.

## Test plan

- `grep -rn 'RCTEventDispatcher' packages/react-native-video/ios/` → no references left (protocol included).
- The file compiles identically; the import was unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)