### PR TITLE
fix(ios): use RCTEventDispatcherProtocol instead of concrete RCTEventDispatcher

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -19,7 +19,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     private var _videoURL: NSURL?
 
     /* Required to publish events */
-    private var _eventDispatcher: RCTEventDispatcher?
+    private var _eventDispatcher: RCTEventDispatcherProtocol?
     private var _videoLoadStarted = false
 
     private var _pendingSeek = false
@@ -194,7 +194,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         #endif
     }
 
-    init(eventDispatcher: RCTEventDispatcher!) {
+    init(eventDispatcher: RCTEventDispatcherProtocol!) {
         super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         ReactNativeVideoManager.shared.registerView(newInstance: self)
         #if USE_GOOGLE_IMA

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -4,7 +4,7 @@ import React
 @objc(RCTVideoManager)
 class RCTVideoManager: RCTViewManager {
     override func view() -> UIView {
-        let eventDispatcher = bridge?.eventDispatcher() as? RCTEventDispatcher
+        let eventDispatcher = bridge?.eventDispatcher()
         return RCTVideo(eventDispatcher: eventDispatcher)
     }
 


### PR DESCRIPTION
## Summary

The iOS implementation references the **concrete `RCTEventDispatcher` class**:

- `ios/Video/RCTVideoManager.swift`: `bridge?.eventDispatcher() as? RCTEventDispatcher`
- `ios/Video/RCTVideo.swift`: `private var _eventDispatcher: RCTEventDispatcher?` and `init(eventDispatcher: RCTEventDispatcher!)`

That class is implemented in `React/CoreModules/RCTEventDispatcher.mm` and belongs to the **`React-CoreModules`** pod — a dependency that neither `react-native-video.podspec` nor React Native's `install_modules_dependencies` declares.

This is a latent undeclared dependency, invisible under static linkage (the default): undefined symbols in a static archive resolve at the app's final link, where React-CoreModules happens to be present. But with:

```ruby
use_frameworks! :linkage => :dynamic
```

the pod is linked as a standalone dynamic framework and fails with:

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_RCTEventDispatcher", referenced from:
       in RCTVideoManager.o
ld: symbol(s) not found for architecture arm64
```

## Why this matters

Dynamic linkage is not an exotic configuration. A common trigger is **Firebase**: consuming the Firebase iOS SDK through Swift Package Manager requires dynamic linking, which forces the app's CocoaPods side to `use_frameworks! :linkage => :dynamic`. In that setup react-native-video currently cannot link at all — this PR unblocks it.

## Fix

Use **`RCTEventDispatcherProtocol`** instead. It is declared in `React/Base/RCTEventDispatcherProtocol.h` (React-Core, which **is** a declared dependency) and exists precisely so libraries don't need the concrete class. `bridge.eventDispatcher()` already returns `id<RCTEventDispatcherProtocol>`, so the `as?` downcast to the concrete class was unnecessary — dropping it also removes the runtime class reference.

No method is ever called on the stored dispatcher (it is only stored in `init` and released in `removeFromSuperview`), so no call-site changes are needed.

## Verification

Built the `react-native-video` pod target of `examples/bare` (RN 0.78.3), then ran `nm -u` on the pod's object files:

- **Before** — `RCTVideoManager.o` contains an undefined `_OBJC_CLASS_$_RCTEventDispatcher`, exactly the symbol the dynamic-framework link fails on.
- **After** — zero undefined `RCTEventDispatcher*` references. The protocol only emits local ObjC metadata (`__PROTOCOL_RCTEventDispatcherProtocol`, etc.), which creates no external linker dependency.

`swiftformat` + `swiftlint` pass clean.

Note: v7 (master) is not affected — the rewritten iOS code no longer uses the class; only a dead `#import "RCTEventDispatcher.h"` remained, removed in #5032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
