### PR TITLE
fix(android): stop SmallVideoPlayerOptimizer from driving an endless layout loop

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/utils/SmallVideoPlayerOptimizer.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/utils/SmallVideoPlayerOptimizer.kt
@@ -47,14 +47,16 @@ object SmallVideoPlayerOptimizer {
     context: Context,
     isFullscreen: Boolean = false
   ) {
+    // For fullscreen mode, use system defaults - no custom optimizations.
+    // Let ExoPlayer use its default controller timeout and styling.
+    // Checked before posting: View.post() on a detached view queues into HandlerActionQueue,
+    // which is only drained on attach, so a Runnable that would only return still accumulates.
+    if (isFullscreen) {
+      return
+    }
+
     playerView.post {
       try {
-        if (isFullscreen) {
-          // For fullscreen mode, use system defaults - no custom optimizations
-          // Let ExoPlayer use its default controller timeout and styling
-          return@post
-        }
-
         // Only apply optimizations if the video player itself is small
         if (!isSmallVideoPlayer(playerView)) {
           return@post
@@ -104,10 +106,14 @@ object SmallVideoPlayerOptimizer {
             else -> secondarySize
           }
 
+          // Writing layoutParams unconditionally calls requestLayout() even when nothing
+          // changed, which re-enters this pass. Only write when the size actually differs.
           val params = child.layoutParams
-          params.width = buttonSize
-          params.height = buttonSize
-          child.layoutParams = params
+          if (params.width != buttonSize || params.height != buttonSize) {
+            params.width = buttonSize
+            params.height = buttonSize
+            child.layoutParams = params
+          }
 
           // Hide less essential buttons on small video players
           when (child.id) {
@@ -133,8 +139,11 @@ object SmallVideoPlayerOptimizer {
     progressContainer?.let { progress ->
       val params = progress.layoutParams as? ViewGroup.MarginLayoutParams
       params?.let {
-        it.height = (4 * context.resources.displayMetrics.density).toInt()
-        progress.layoutParams = it
+        val targetHeight = (4 * context.resources.displayMetrics.density).toInt()
+        if (it.height != targetHeight) {
+          it.height = targetHeight
+          progress.layoutParams = it
+        }
       }
     }
   }

--- a/packages/react-native-video/android/src/main/java/com/twg/video/view/VideoView.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/view/VideoView.kt
@@ -193,9 +193,6 @@ class VideoView @JvmOverloads constructor(
       MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
     )
     layout(left, top, right, bottom)
-
-    // Additional layout fixes for small video players
-    applySmallPlayerLayoutFixes()
   }
 
   override fun requestLayout() {
@@ -553,13 +550,16 @@ class VideoView @JvmOverloads constructor(
   private fun PlayerView.configureForSmallPlayer() {
     SmallVideoPlayerOptimizer.applyOptimizations(this, context, isFullscreen = false)
 
-    // Also apply after any layout changes
-    viewTreeObserver.addOnGlobalLayoutListener {
-      SmallVideoPlayerOptimizer.applyOptimizations(this, context, isFullscreen = false)
+    // Re-apply when this view's own bounds change. Scoped to the PlayerView rather than the
+    // window-wide ViewTreeObserver: a global layout listener registered before attach is merged
+    // into the window's observer and never removed on detach, which retains every PlayerView for
+    // the lifetime of the Activity. A layout-change listener lives on the view itself.
+    addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
+      val sizeChanged =
+        (right - left) != (oldRight - oldLeft) || (bottom - top) != (oldBottom - oldTop)
+      if (sizeChanged) {
+        SmallVideoPlayerOptimizer.applyOptimizations(this, context, isFullscreen = false)
+      }
     }
-  }
-
-  private fun applySmallPlayerLayoutFixes() {
-    SmallVideoPlayerOptimizer.applyOptimizations(playerView, context, isFullscreen = false)
   }
 }


### PR DESCRIPTION
## Summary

`SmallVideoPlayerOptimizer` re-triggers the layout pass it reacts to. The result is a self-sustaining loop that keeps the main thread busy indefinitely — including while the app is backgrounded — plus a listener that retains every `PlayerView` for the lifetime of the `Activity`.

This is a fix, not a redesign: **what the optimizer applies is unchanged.** Button sizes (48/44dp), hidden `shuffle`/`repeat_toggle`/`vr`, 12sp time text, 4dp progress row, the 400dp/300dp threshold and the fullscreen skip all stay exactly as they were.

## Root cause

Three defects compound:

**1. `layoutParams` written unconditionally** — `optimizeButtons` / `optimizeProgressBar`

`View.setLayoutParams()` calls `requestLayout()` **unconditionally**, even when the values are identical (`View.java`, `setLayoutParams` → `requestLayout()`). Since the optimizer rewrote the same sizes on every pass, every pass scheduled another one.

**2. That closes a loop that bypasses frame throttling**

`VideoView.requestLayout()` posts `layoutRunnable`, which calls `measure()` + `layout()` **directly**, not through `ViewRootImpl`. So the cycle is:

```
VideoView.requestLayout() → post(layoutRunnable)      ← Handler message #1
  → measure() + layout()  (bypasses ViewRootImpl)
    → applySmallPlayerLayoutFixes() → playerView.post ← Handler message #2
      → child.layoutParams = params → requestLayout() ⟲
```

Two `Handler` messages per lap, no `Choreographer` in the path, therefore no frame cap.

**3. `OnGlobalLayoutListener` is never removed**

`configureForSmallPlayer()` runs from `createPlayerView()`, i.e. **before attach**. At that point `getViewTreeObserver()` returns the view's private floating observer, which on attach is merged into the **window's** observer (`View.dispatchAttachedToWindow` → `info.mTreeObserver.merge(mFloatingTreeObserver)`). `dispatchDetachedFromWindow()` removes nothing, so every `PlayerView` ever created stays reachable for the lifetime of the `Activity`.

Note the `isSmallDimensions` threshold (`width <= 400dp || height <= 300dp`) matches essentially every phone in portrait, so this is the default path, not an edge case. Same observation as #4913.

## The fix

1. **Write `layoutParams` only when the value actually differs.** This alone cuts the single edge that closes both loop paths.
2. **`OnGlobalLayoutListener` → `OnLayoutChangeListener` on the `PlayerView` itself.** It lives in the view's own `ListenerInfo`, so the view↔lambda cycle is collected with the view.
3. **Drop `applySmallPlayerLayoutFixes()` from `layoutRunnable`** (and the now-unused helper). Redundant once the layout-change listener exists, and it was the second path feeding the loop. **The React Native sizing workaround (`measure` + `layout` in `requestLayout()`) is untouched.**
4. **Return early for `isFullscreen` before posting** instead of posting a `Runnable` that only returns — `View.post()` on a detached view queues into `HandlerActionQueue`, which is only drained on attach.

## Measurements

Release build, Android 16 emulator, one inline 16:9 player (379×213 dp), static screen, nothing being interacted with.

| Metric | Before | After |
|---|---|---|
| `applyOptimizations` calls / s | up to **101,934** | **0** at rest |
| `layoutParams` writes / s | up to **1,325,142** | **0** after one pass |
| Main-thread CPU | 7158 ticks / 90 s (~80% of a core) | 284 ticks / 90 s (~3%) |
| RSS growth | +9,200 kB / 90 s | +208 kB / 90 s |
| `Choreographer` | `Skipped 869 frames` | none |
| `dumpsys meminfo` | **timed out** (process could not service the binder call) | responds immediately |
| Views retained per mount/unmount cycle | ~43 | ~5 |

The loop also explains the ANR signature: the main thread sits in `Runnable` state inside the optimizer with the app in the background, so the watchdog fires.

## Verification

No automated tests exist for this module (no Android unit tests, no ktlint/detekt, no Android CI workflow), so this was verified manually with temporary counters compiled into the optimizer and removed before commit.

| Scenario | Result |
|---|---|
| Landscape, player above threshold | optimizer correctly skips (`treeWalks=0`) |
| **Rotate large → small** | listener fires, applies 11 `layoutParams` writes in the first second, then 0 — re-application works and converges |
| Scroll ×10 | 1 tree walk/s, 0 writes |
| Fullscreen enter | zero calls |
| Fullscreen exit | brief burst, 0 writes — sizes survived the reparent |
| `resizeMode` cycling ×8 | max 2 walks/s, 0 writes |
| 20× mount/unmount + forced GC | +96 Views (~5/cycle), heap stable |
| Paused, 30 s | **0 calls** |
| Control sizes after the full matrix | 48 / 44 / 4 dp, `shuffle`/`repeat_toggle`/`vr` absent |

The residual ~1 call/s seen during playback is media3 re-laying out the time bar once per second as the position updates; it drops to zero when playback is paused.

Behaviour was also confirmed by A/B: a fresh mount in landscape (player above threshold) renders media3's default control sizing, and rotating to portrait produces the optimized sizing.

Framework semantics used above were read from AOSP `android-36.1` sources (`View.java`, `ViewGroup.java`, `HandlerActionQueue.java`) and media3 1.4.1 sources, not assumed.

## Why removing the `layoutRunnable` call is safe

The obvious reviewer question is whether `applySmallPlayerLayoutFixes()` in `layoutRunnable` was load-bearing. It was not, and the strongest argument is that media3's own reflow trigger uses the identical condition as the new listener.

`PlayerControlViewLayoutManager.onLayoutChange`:

```java
boolean widthChanged = (right - left) != (oldRight - oldLeft);
if (!isMinimalMode && widthChanged) {
  v.post(this::onLayoutWidthChanged);
}
```

`onLayoutWidthChanged()` is the **only** runtime mutation of the controller's view tree in media3 (moving buttons between `exo_basic_controls` and `exo_extra_controls`). Its guard is the same width comparison the new `OnLayoutChangeListener` uses, so re-application happens exactly when media3 itself decides the controller needs reflowing. `updateLayoutForSizeChange()` is likewise driven by `useMinimalMode()`, which is computed from width/height.

Even if a pass were missed after such a move, the applied sizes survive it: `ViewGroup.addView(View, int)` reuses `child.getLayoutParams()` and only regenerates when null, and both containers are `LinearLayout`, so `checkLayoutParams` passes.

Cases checked against media3 1.4.1 and AOSP sources:

| Case | Covered by | Reference |
|---|---|---|
| First mount | direct call from `configureForSmallPlayer` (queued, runs on attach) **and** first layout 0 → N | — |
| `surfaceType` change | `createPlayerView()` → `configureForSmallPlayer()` on the new view | — |
| `useController` false → true | controller exists regardless of the flag | `PlayerView.java:566-589` |
| `exo_progress` created at runtime? | no — `DefaultTimeBar` swaps the placeholder in the constructor | `PlayerControlView.java:628-643` |
| Buttons moved to/from overflow | same width condition as our listener, and `LayoutParams` survive the move | `PlayerControlViewLayoutManager.java:489-492`, `ViewGroup.java:5085` |
| Minimal-mode flip | derived from width/height | `useMinimalMode()` |
| media3 resetting button sizes | never — `setLayoutParams` only on `timeBar` and settings RecyclerView holders | — |
| Fullscreen enter/exit | measured: 0 writes on exit, sizes intact | — |
| Rotation / multi-window / keyboard resize | size change | measured |
| Activity recreation | new view tree → `configureForSmallPlayer()` | — |

The only case the old call covered and the new trigger does not is a `VideoView.requestLayout()` that produces neither a `PlayerView` layout nor a size change — in which case nothing about the controller changed and there is nothing to re-apply.

If a wider safety margin is ever wanted, dropping the `sizeChanged` guard makes the optimizer re-run on every real layout of the `PlayerView`. Measured cost: 0/s at rest, ~1 no-op tree walk/s during playback — the same cost the removed `layoutRunnable` call had, with no risk of reintroducing the loop since the writes are now conditional.

