### PR TITLE
fix(android): pause playback when rate is zero

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
@@ -41,6 +41,15 @@ import com.twg.video.view.VideoView
 import java.lang.ref.WeakReference
 import kotlin.math.max
 
+internal fun Player.setPlaybackRate(rate: Double) {
+  if (rate <= 0.0) {
+    pause()
+    return
+  }
+
+  playbackParameters = playbackParameters.withSpeed(rate.toFloat())
+}
+
 @UnstableApi
 @DoNotStrip
 class HybridVideoPlayer() : HybridVideoPlayerSpec(), AutoCloseable {
@@ -178,7 +187,7 @@ class HybridVideoPlayer() : HybridVideoPlayerSpec(), AutoCloseable {
   override var rate: Double by mainThreadProperty(
     get = { player.playbackParameters.speed.toDouble() },
     set = { value ->
-      player.playbackParameters = player.playbackParameters.withSpeed(value.toFloat())
+      player.setPlaybackRate(value)
     }
   )
 


### PR DESCRIPTION
## Summary

Prevents an Android crash when setting `player.rate` to `0`.

Non-positive playback rates now pause the player instead of being passed to Media3's `PlaybackParameters`, which rejects values less than or equal to zero.

## Motivation

Media3 requires playback speed to be greater than zero. Passing `rate = 0` previously caused an `IllegalArgumentException`, although the documented behavior is to pause playback.

Fixes #4812.

## Changes

- Pause the Android player when `rate <= 0`.
- Preserve the existing playback-speed behavior for positive values.

## Platforms affected

- [x] Android
- [ ] iOS
- [ ] visionOS
- [ ] tvOS / Android TV
- [ ] Windows
- [ ] Web

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only

## Test plan

1. Start video playback in the example app on Android.
2. Set `player.rate = 0`.
3. Confirm that playback pauses without throwing an `IllegalArgumentException` or crashing the app.
4. Confirm that positive playback rates continue to update the playback speed.

Additionally, Android unit tests covering zero, negative, and positive playback rates passed successfully.

## Checklist

- [x] I read the [contributing guidelines](https://github.com/TheWidlarzGroup/react-native-video/blob/master/CONTRIBUTING.md).
- [x] I updated the documentation / README where relevant.
- [x] If this changes how the library is used (API, props, events, behavior), I updated the AI agent skill (`skills/react-native-video/`) to match.
- [x] This PR is focused on a single concern.
- [x] I tested my changes on at least one platform.