### PR TITLE
fix: rebind VideoView manager when native view is recreated

### DIFF
--- a/packages/react-native-video/src/core/video-view/VideoView.tsx
+++ b/packages/react-native-video/src/core/video-view/VideoView.tsx
@@ -77,25 +77,23 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
   ) => {
     const nitroId = React.useMemo(() => nitroIdCounter++, []);
     const nitroViewManager = React.useRef<VideoViewViewManager | null>(null);
-    const [isManagerReady, setIsManagerReady] = React.useState(false);
+    const [managerGeneration, setManagerGeneration] = React.useState(0);
 
     const setupViewManager = React.useCallback(
       (id: number) => {
         try {
-          if (nitroViewManager.current === null) {
-            nitroViewManager.current =
-              VideoViewViewManagerFactory.createViewManager(id);
+          nitroViewManager.current =
+            VideoViewViewManagerFactory.createViewManager(id);
 
-            // Should never happen
-            if (!nitroViewManager.current) {
-              throw new VideoError(
-                'view/not-found',
-                'Failed to create View Manager'
-              );
-            }
+          // Should never happen
+          if (!nitroViewManager.current) {
+            throw new VideoError(
+              'view/not-found',
+              'Failed to create View Manager'
+            );
           }
 
-          setIsManagerReady(true);
+          setManagerGeneration((generation) => generation + 1);
         } catch (error) {
           const parsedError = tryParseNativeVideoError(error);
 
@@ -214,7 +212,7 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
       return () => {
         if (nitroViewManager.current) {
           nitroViewManager.current.clearAllListeners();
-          setIsManagerReady(false);
+          setManagerGeneration(0);
         }
       };
     }, []);
@@ -280,7 +278,7 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
       willExitFullscreen,
       willEnterPictureInPicture,
       willExitPictureInPicture,
-      isManagerReady,
+      managerGeneration,
     ]);
 
     // Update non-event props
@@ -305,7 +303,7 @@ const VideoView = React.forwardRef<VideoViewRef, VideoViewProps>(
       autoEnterPictureInPicture,
       resizeMode,
       props,
-      isManagerReady,
+      managerGeneration,
     ]);
 
     return (


### PR DESCRIPTION
## Summary

Rebinds `VideoView` to its native view when the underlying Fabric view is recreated while the React component and player remain mounted.

## Motivation

When `react-native-screens` detaches and recreates a covered Fabric view, the existing `VideoViewViewManager` continues pointing to the old native view. The readiness boolean also remains `true`, so the effects responsible for assigning the player and registering listeners do not run again.

This leaves the recreated native view permanently black even though the JS player remains active and continues emitting events.

Fixes #5018.

## Changes

- Recreate `VideoViewViewManager` on every `onNitroIdChange` event.
- Replace the readiness boolean with a generation counter.
- Re-run prop and listener effects after every native view recreation.
- Rebind the existing player to the recreated native view.

## Platforms affected

- [x] Android
- [x] iOS
- [ ] visionOS
- [ ] tvOS / Android TV
- [ ] Windows
- [ ] Web

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only

## Test plan

Tested using the example app with React Native 0.81.5 and the New Architecture enabled on an iPhone 12 simulator.

1. Mounted six looping `VideoView` instances.
2. Pushed a covering native-stack screen.
3. Recreated the underlying native video views while keeping the React components and players mounted.
4. Navigated back to the video screen.
5. Verified that all videos continued rendering and progress events continued updating.

Before the fix, the video surfaces remained black after returning while progress events continued. After the fix, the existing players were rebound and video rendering resumed correctly.

Additional checks:

- TypeScript typecheck
- ESLint
- Commitlint
- Git whitespace validation

## Checklist

- [x] I read the [contributing guidelines](https://github.com/TheWidlarzGroup/react-native-video/blob/master/CONTRIBUTING.md).
- [x] I updated the documentation / README where relevant.
- [x] If this changes how the library is used (API, props, events, behavior), I updated the AI agent skill (`skills/react-native-video/`) to match.
- [x] This PR is focused on a single concern.
- [x] I tested my changes on at least one platform.