### PR TITLE
fix(android): make PiP helper fragment restorable

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/core/fragments/PictureInPictureHelperFragment.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/core/fragments/PictureInPictureHelperFragment.kt
@@ -14,11 +14,34 @@ import com.twg.video.view.VideoView
 import java.util.UUID
 
 @OptIn(UnstableApi::class)
-class PictureInPictureHelperFragment(private val videoView: VideoView) : Fragment() {
+class PictureInPictureHelperFragment() : Fragment() {
+  private var videoView: VideoView? = null
   val id: String = UUID.randomUUID().toString()
+
+  constructor(videoView: VideoView) : this() {
+    this.videoView = videoView
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    if (videoView == null) {
+      // The original view is gone after restoration. React Native will add a new helper
+      // when it remounts the VideoView, so remove this orphaned fragment.
+      Handler(Looper.getMainLooper()).post {
+        if (isAdded) {
+          parentFragmentManager.beginTransaction()
+            .remove(this)
+            .commitAllowingStateLoss()
+        }
+      }
+    }
+  }
 
   override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
     super.onPictureInPictureModeChanged(isInPictureInPictureMode)
+
+    val videoView = videoView ?: return
 
     if (isInPictureInPictureMode) {
       var currentPipVideo = VideoManager.getCurrentPictureInPictureVideo()


### PR DESCRIPTION
## Summary

Prevents an Android crash when `FragmentManager` restores `PictureInPictureHelperFragment` after process death or Activity recreation.

## Motivation

Android requires fragments to expose a public no-argument constructor so they can be recreated by `FragmentManager`.

`PictureInPictureHelperFragment` previously only accepted a `VideoView` constructor argument. Restoring it through reflection therefore caused a `Fragment$InstantiationException` with an underlying `NoSuchMethodException`.

Fixes #4917.

## Changes

- Added a public no-argument constructor to `PictureInPictureHelperFragment`.
- Retained the existing constructor accepting a `VideoView`.
- Made the `VideoView` reference nullable for framework-restored fragment instances.
- Removed restored orphan fragments that no longer have their original `VideoView`.
- Safely ignored PiP callbacks when no `VideoView` is attached.

## Platforms affected

- [x] Android
- [ ] iOS
- [ ] visionOS
- [ ] tvOS / Android TV
- [ ] Windows
- [ ] Web

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only

## Test plan

- Verified that `FragmentFactory` can instantiate `PictureInPictureHelperFragment` using its no-argument constructor.
- Ran the Android unit test suite with `:react-native-video:testDebugUnitTest`.
- Reproduced the original crash on an Android emulator with **Don't keep activities** enabled:
  1. Started video playback.
  2. Entered Picture-in-Picture mode.
  3. Closed Picture-in-Picture, causing the Activity to be destroyed.
  4. Reopened the application.
- Before the change, reopening the application crashed with `Fragment$InstantiationException` caused by `NoSuchMethodException`.
- After the change, the Activity and fragment state are restored without a crash.

## Checklist

- [x] I read the [contributing guidelines](https://github.com/TheWidlarzGroup/react-native-video/blob/master/CONTRIBUTING.md).
- [x] I updated the documentation / README where relevant.
- [x] If this changes how the library is used (API, props, events, behavior), I updated the AI agent skill (`skills/react-native-video/`) to match.
- [x] This PR is focused on a single concern.
- [x] I tested my changes on at least one platform.