### PR TITLE
fix(ios): support PhotoKit ph:// video sources

### DIFF
--- a/packages/react-native-video/ios/core/Extensions/AVAsset+getAssetInformation.swift
+++ b/packages/react-native-video/ios/core/Extensions/AVAsset+getAssetInformation.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 
-extension AVURLAsset {
+extension AVAsset {
   func getAssetInformation() async throws -> VideoInformation {
     // Default values
     var bitrate = Double.nan
@@ -11,7 +11,13 @@ extension AVURLAsset {
     var isLive = false
     var orientation: VideoOrientation = .unknown
 
-    let fileSize = try await VideoFileHelper.getFileSize(for: url)
+    let url = (self as? AVURLAsset)?.url
+    let fileSize: Int64
+    if let url {
+      fileSize = try await VideoFileHelper.getFileSize(for: url)
+    } else {
+      fileSize = -1
+    }
 
     // Check if asset is live stream
     if duration.flags.contains(.indefinite) {
@@ -34,7 +40,7 @@ extension AVURLAsset {
       if #available(iOS 14.0, tvOS 14.0, visionOS 1.0, *) {
         isHDR = videoTrack.hasMediaCharacteristic(.containsHDRVideo)
       }
-    } else if url.pathExtension == "m3u8" {
+    } else if let url, url.pathExtension.lowercased() == "m3u8" {
       // For HLS streams, we cannot get video track information directly
       // So we download manifest and try to extract video information from it
 

--- a/packages/react-native-video/ios/core/Extensions/AVPlayerItem+externalSubtitles.swift
+++ b/packages/react-native-video/ios/core/Extensions/AVPlayerItem+externalSubtitles.swift
@@ -9,13 +9,13 @@ import AVFoundation
 import Foundation
 
 extension AVPlayerItem {
-  static func withExternalSubtitles(for asset: AVURLAsset, config: NativeVideoConfig) async throws
+  static func withExternalSubtitles(for asset: AVAsset, config: NativeVideoConfig) async throws
     -> AVPlayerItem
   {
     if config.externalSubtitles?.isEmpty != false {
       return AVPlayerItem(asset: asset)
     }
-      
+
     let supportedExternalSubtitles = config.externalSubtitles?.filter { subtitle in
       ExternalSubtitlesUtils.isSubtitleTypeSupported(subtitle: subtitle)
     }
@@ -23,10 +23,12 @@ extension AVPlayerItem {
     if supportedExternalSubtitles?.isEmpty == true {
       return AVPlayerItem(asset: asset)
     }
-      
-    if asset.url.pathExtension == "m3u8" {
-        return try await ExternalSubtitlesUtils.modifyStreamManifestWithExternalSubtitles(
-          for: asset, config: config)
+
+    if let urlAsset = asset as? AVURLAsset,
+      urlAsset.url.pathExtension.lowercased() == "m3u8"
+    {
+      return try await ExternalSubtitlesUtils.modifyStreamManifestWithExternalSubtitles(
+        for: urlAsset, config: config)
     }
 
     return try await ExternalSubtitlesUtils.createCompositionWithExternalSubtitles(

--- a/packages/react-native-video/ios/core/Spec/NativeVideoPlayerSourceSpec.swift
+++ b/packages/react-native-video/ios/core/Spec/NativeVideoPlayerSourceSpec.swift
@@ -14,8 +14,8 @@ public typealias NativeVideoPlayerSource = NativeVideoPlayerSourceSpec & HybridV
 public protocol NativeVideoPlayerSourceSpec {
   // MARK: - Properties
   
-  /// The underlying AVURLAsset instance
-  var asset: AVURLAsset? { get set }
+  /// The underlying AVAsset instance
+  var asset: AVAsset? { get set }
   
   /// The URL of the video source
   var url: URL { get }
@@ -28,8 +28,8 @@ public protocol NativeVideoPlayerSourceSpec {
   /// Initialize the asset asynchronously
   func initializeAsset() async throws
   
-  /// Get non-null AVURLAsset instance (self.asset)
-  func getAsset() async throws -> AVURLAsset
+  /// Get non-null AVAsset instance (self.asset)
+  func getAsset() async throws -> AVAsset
   
   /// Release the asset resources
   func releaseAsset()

--- a/packages/react-native-video/ios/core/Utils/ExternalSubtitlesUtils.swift
+++ b/packages/react-native-video/ios/core/Utils/ExternalSubtitlesUtils.swift
@@ -18,7 +18,7 @@ enum ExternalSubtitlesUtils {
   }
 
   static func createCompositionWithExternalSubtitles(
-    for asset: AVURLAsset,
+    for asset: AVAsset,
     config: NativeVideoConfig
   ) async throws -> AVPlayerItem {
     let supportedSubtitles = (config.externalSubtitles ?? []).filter { subtitle in

--- a/packages/react-native-video/ios/core/Utils/PhotoLibraryAssetLoader.swift
+++ b/packages/react-native-video/ios/core/Utils/PhotoLibraryAssetLoader.swift
@@ -1,0 +1,207 @@
+//
+//  PhotoLibraryAssetLoader.swift
+//  ReactNativeVideo
+//
+
+import AVFoundation
+import Foundation
+import Photos
+
+protocol PhotoLibraryAssetLoading: Sendable {
+  func loadAsset(for uri: String) async throws -> AVAsset
+}
+
+struct PhotoLibraryAssetRequest: Sendable {
+  let cancel: @Sendable () -> Void
+}
+
+protocol PhotoLibraryAssetClient: Sendable {
+  func requestAsset(
+    forLocalIdentifier identifier: String,
+    options: PHVideoRequestOptions,
+    completion: @escaping @Sendable (Result<AVAsset, Error>) -> Void
+  ) -> PhotoLibraryAssetRequest?
+}
+
+private struct SystemPhotoLibraryAssetClient: PhotoLibraryAssetClient {
+  func requestAsset(
+    forLocalIdentifier identifier: String,
+    options: PHVideoRequestOptions,
+    completion: @escaping @Sendable (Result<AVAsset, Error>) -> Void
+  ) -> PhotoLibraryAssetRequest? {
+    guard let photoAsset = PHAsset.fetchAssets(
+      withLocalIdentifiers: [identifier],
+      options: nil
+    ).firstObject,
+      photoAsset.mediaType == .video
+    else {
+      return nil
+    }
+
+    let imageManager = PHImageManager.default()
+    let requestID = imageManager.requestAVAsset(
+      forVideo: photoAsset,
+      options: options
+    ) { asset, _, info in
+      if let isCancelled = info?[PHImageCancelledKey] as? NSNumber,
+         isCancelled.boolValue {
+        completion(.failure(CancellationError()))
+      } else if let error = info?[PHImageErrorKey] as? Error {
+        completion(.failure(error))
+      } else if let asset {
+        completion(.success(asset))
+      } else {
+        completion(.failure(SourceError.failedToInitializeAsset.error()))
+      }
+    }
+
+    return PhotoLibraryAssetRequest {
+      imageManager.cancelImageRequest(requestID)
+    }
+  }
+}
+
+private final class PhotoLibraryAssetLoadState: @unchecked Sendable {
+  private enum Status {
+    case pending
+    case completed
+    case cancelled
+  }
+
+  private let lock = NSLock()
+  private var status: Status = .pending
+  private var continuation: CheckedContinuation<AVAsset, Error>?
+  private var request: PhotoLibraryAssetRequest?
+
+  func installContinuation(_ continuation: CheckedContinuation<AVAsset, Error>) {
+    let shouldCancel: Bool = withLock {
+      switch status {
+      case .pending:
+        self.continuation = continuation
+        return false
+      case .cancelled:
+        return true
+      case .completed:
+        return false
+      }
+    }
+
+    if shouldCancel {
+      continuation.resume(throwing: CancellationError())
+    }
+  }
+
+  func installRequest(_ request: PhotoLibraryAssetRequest) {
+    let shouldCancel: Bool = withLock {
+      switch status {
+      case .pending:
+        self.request = request
+        return false
+      case .cancelled:
+        return true
+      case .completed:
+        return false
+      }
+    }
+
+    if shouldCancel {
+      request.cancel()
+    }
+  }
+
+  func complete(_ result: Result<AVAsset, Error>) {
+    let continuation: CheckedContinuation<AVAsset, Error>? = withLock {
+      guard case .pending = status else { return nil }
+      status = .completed
+      request = nil
+      let continuation = self.continuation
+      self.continuation = nil
+      return continuation
+    }
+
+    continuation?.resume(with: result)
+  }
+
+  func cancel() {
+    let cancellation: (
+      continuation: CheckedContinuation<AVAsset, Error>?,
+      request: PhotoLibraryAssetRequest?
+    )? = withLock {
+      guard case .pending = status else { return nil }
+      status = .cancelled
+      let cancellation = (continuation, request)
+      continuation = nil
+      request = nil
+      return cancellation
+    }
+
+    cancellation?.request?.cancel()
+    cancellation?.continuation?.resume(throwing: CancellationError())
+  }
+
+  @discardableResult
+  private func withLock<T>(_ operation: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return operation()
+  }
+}
+
+final class PhotoLibraryAssetLoader: PhotoLibraryAssetLoading {
+  private static let schemeDelimiter = "ph://"
+
+  private let client: any PhotoLibraryAssetClient
+
+  init() {
+    client = SystemPhotoLibraryAssetClient()
+  }
+
+  init(client: any PhotoLibraryAssetClient) {
+    self.client = client
+  }
+
+  func loadAsset(for uri: String) async throws -> AVAsset {
+    guard uri.range(
+      of: Self.schemeDelimiter,
+      options: [.anchored, .caseInsensitive]
+    ) != nil else {
+      throw SourceError.invalidUri(uri: uri).error()
+    }
+
+    let identifier = String(uri.dropFirst(Self.schemeDelimiter.count))
+    guard !identifier.isEmpty else {
+      throw SourceError.invalidUri(uri: uri).error()
+    }
+
+    let options = PHVideoRequestOptions()
+    options.isNetworkAccessAllowed = true
+    let state = PhotoLibraryAssetLoadState()
+
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        state.installContinuation(continuation)
+        guard !Task.isCancelled else {
+          state.cancel()
+          return
+        }
+
+        guard let request = client.requestAsset(
+          forLocalIdentifier: identifier,
+          options: options,
+          completion: { result in
+            state.complete(result)
+          }
+        ) else {
+          state.complete(
+            .failure(SourceError.photoLibraryAssetNotFound(uri: uri).error())
+          )
+          return
+        }
+
+        state.installRequest(request)
+      }
+    } onCancel: {
+      state.cancel()
+    }
+  }
+}

--- a/packages/react-native-video/ios/core/VideoError.swift
+++ b/packages/react-native-video/ios/core/VideoError.swift
@@ -74,6 +74,7 @@ enum PlayerError: VideoError {
 // MARK: - SourceError
 enum SourceError: VideoError {
   case invalidUri(uri: String)
+  case photoLibraryAssetNotFound(uri: String)
   case missingReadFilePermission(uri: String)
   case fileDoesNotExist(uri: String)
   case failedToInitializeAsset
@@ -84,6 +85,8 @@ enum SourceError: VideoError {
     switch self {
     case .invalidUri:
       return "source/invalid-uri"
+    case .photoLibraryAssetNotFound:
+      return "source/photo-library-asset-not-found"
     case .missingReadFilePermission:
       return "source/missing-read-file-permission"
     case .fileDoesNotExist:
@@ -101,6 +104,8 @@ enum SourceError: VideoError {
     switch self {
     case let .invalidUri(uri: uri):
       return "Invalid source file uri: \(uri)"
+    case let .photoLibraryAssetNotFound(uri: uri):
+      return "Photo library video was not found at URI: \(uri)"
     case let .missingReadFilePermission(uri: uri):
       return "Missing read file permission for source file at \(uri)"
     case let .fileDoesNotExist(uri: uri):
@@ -165,5 +170,3 @@ extension VideoError {
     return RuntimeError.error(withMessage: getMessage())
   }
 }
-
-

--- a/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayer/HybridVideoPlayer.swift
@@ -541,12 +541,12 @@ class HybridVideoPlayer: HybridVideoPlayerSpec, NativeVideoPlayerSpec {
     )
     try ensureCurrentLoad(context)
 
-    let isNetworkSource = _source.url.isFileURL == false
+    let isLocalSource = _source.url.isFileURL || _source.url.scheme?.lowercased() == "ph"
     _eventEmitter?.onLoadStart(
-      .init(sourceType: isNetworkSource ? .network : .local, source: _source)
+      .init(sourceType: isLocalSource ? .local : .network, source: _source)
     )
 
-    let asset: AVURLAsset
+    let asset: AVAsset
     if let source = _source as? HybridVideoPlayerSource {
       asset = try await source.getAsset(
         isCurrent: { self.sourceLoader.isCurrent(context.token) }

--- a/packages/react-native-video/ios/hybrids/VideoPlayerSource/HybridVideoPlayerSource.swift
+++ b/packages/react-native-video/ios/hybrids/VideoPlayerSource/HybridVideoPlayerSource.swift
@@ -15,17 +15,18 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
 
   let url: URL
   private let sourceLoader = SourceLoader()
-  private var storedAsset: AVURLAsset?
+  private let photoLibraryAssetLoader: any PhotoLibraryAssetLoading
+  private var storedAsset: AVAsset?
   private var storedDrmManager: DRMManagerSpec?
 
   private struct PreparedAsset {
-    let asset: AVURLAsset
+    let asset: AVAsset
     let drmManager: DRMManagerSpec?
   }
 
   private struct InformationRequest {
     let token: SourceLoader.Token
-    let asset: AVURLAsset?
+    let asset: AVAsset?
   }
 
   private struct AssetInformationResult {
@@ -33,7 +34,7 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
     let information: VideoInformation
   }
 
-  var asset: AVURLAsset? {
+  var asset: AVAsset? {
     get { sourceLoader.withState { storedAsset } }
     set {
       let releasedAsset = sourceLoader.cancel {
@@ -50,9 +51,13 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
     set { sourceLoader.withState { storedDrmManager = newValue } }
   }
 
-  init(config: NativeVideoConfig) throws {
+  init(
+    config: NativeVideoConfig,
+    photoLibraryAssetLoader: any PhotoLibraryAssetLoading = PhotoLibraryAssetLoader()
+  ) throws {
     uri = config.uri
     self.config = config
+    self.photoLibraryAssetLoader = photoLibraryAssetLoader
 
     guard let url = URL(string: uri) else {
       throw SourceError.invalidUri(uri: uri).error()
@@ -77,7 +82,7 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
     let request: InformationRequest
 
     do {
-      var existingAsset: AVURLAsset?
+      var existingAsset: AVAsset?
       guard let token = try sourceLoader.begin(onBegin: {
         existingAsset = storedAsset
       }) else {
@@ -145,14 +150,14 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
     _ = try await getAsset()
   }
 
-  func getAsset() async throws -> AVURLAsset {
+  func getAsset() async throws -> AVAsset {
     try await getAsset(isCurrent: { true })
   }
 
-  func getAsset(isCurrent: @escaping () -> Bool) async throws -> AVURLAsset {
+  func getAsset(isCurrent: @escaping () -> Bool) async throws -> AVAsset {
     guard isCurrent() else { throw CancellationError() }
 
-    var existingAsset: AVURLAsset?
+    var existingAsset: AVAsset?
     let token = try sourceLoader.begin(if: {
       existingAsset = storedAsset
       return existingAsset == nil
@@ -160,6 +165,9 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
 
     if let existingAsset {
       guard isCurrent() else { throw CancellationError() }
+      if config.drm != nil, !(existingAsset is AVURLAsset) {
+        throw SourceError.unsupportedContentType(uri: uri).error()
+      }
       return existingAsset
     }
 
@@ -197,7 +205,7 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
   }
 
   private func prepareAsset(
-    existing: AVURLAsset?,
+    existing: AVAsset?,
     token: SourceLoader.Token,
     isCurrent: () -> Bool
   ) async throws -> PreparedAsset {
@@ -206,14 +214,20 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
     }
 
     if let existing {
+      if config.drm != nil, !(existing is AVURLAsset) {
+        throw SourceError.unsupportedContentType(uri: uri).error()
+      }
+
       return PreparedAsset(
         asset: existing,
         drmManager: sourceLoader.withState { storedDrmManager }
       )
     }
 
-    let asset: AVURLAsset
-    if let headers = config.headers {
+    let asset: AVAsset
+    if url.scheme?.lowercased() == "ph" {
+      asset = try await photoLibraryAssetLoader.loadAsset(for: uri)
+    } else if let headers = config.headers {
       asset = AVURLAsset(
         url: url,
         options: ["AVURLAssetHTTPHeaderFieldsKey": headers]
@@ -224,13 +238,17 @@ class HybridVideoPlayerSource: HybridVideoPlayerSourceSpec, NativeVideoPlayerSou
 
     let drmManager: DRMManagerSpec?
     if let drmParams = config.drm {
+      guard let urlAsset = asset as? AVURLAsset else {
+        throw SourceError.unsupportedContentType(uri: uri).error()
+      }
+
       let manager = try PluginsRegistry.shared.getDrmManager(source: self)
       guard let manager else {
         throw LibraryError.DRMPluginNotFound.error()
       }
 
       do {
-        try manager.createContentKeyRequest(for: asset, drmParams: drmParams)
+        try manager.createContentKeyRequest(for: urlAsset, drmParams: drmParams)
       } catch {
         print("[ReactNativeVideo] Failed to create content key request for DRM: \(drmParams)")
       }

--- a/packages/react-native-video/src/core/types/VideoError.ts
+++ b/packages/react-native-video/src/core/types/VideoError.ts
@@ -10,6 +10,7 @@ export type PlayerError =
 
 export type SourceError =
   | 'source/invalid-uri'
+  | 'source/photo-library-asset-not-found'
   | 'source/missing-read-file-permission'
   | 'source/file-does-not-exist'
   | 'source/failed-to-initialize-asset'


### PR DESCRIPTION
## Summary

Restores support for playing iOS PhotoKit `ph://` video sources with the v7 `useVideoPlayer()` API.

## Motivation

Fixes #5029.

v7 created an `AVURLAsset` directly from every source URI. A PhotoKit local identifier is not a directly playable URL, so `ph://` sources displayed a black video view. v6 resolved these identifiers through PhotoKit before creating the player item.

## Changes

- Resolve `ph://` local identifiers through `PHAsset` and `PHImageManager.requestAVAsset`.
- Allow network access for videos stored in iCloud.
- Propagate task cancellation to the PhotoKit request.
- Support generic `AVAsset` results returned for edited or composed PhotoKit videos.
- Keep URL-only behavior explicitly guarded for DRM, HLS manifest injection, and file-size lookup.
- Report PhotoKit sources as local.
- Add the typed `source/photo-library-asset-not-found` error.

## Platforms affected

- [ ] Android
- [x] iOS
- [ ] visionOS
- [ ] tvOS / Android TV
- [ ] Windows
- [ ] Web

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only

## Test plan

- Built and installed the example app as a signed Release build on an iPhone 17 Pro running iOS 26.6.
- Selected a real video from the Photos library and passed its exact `ph://<localIdentifier>` value to `useVideoPlayer()`.
- Verified that the player reached `readyToPlay`, rendered a video frame, and advanced playback time without Metro.
- Reproduced the regression before the fix: a direct `AVURLAsset(ph://...)` was not playable.
- Ran a local PhotoKit integration harness with 16 passing tests, covering generic `AVAsset` handling, cancellation races, DRM guards, subtitles, missing assets, and case-insensitive schemes.
- Ran Swift parsing, TypeScript type checking, ESLint, and `git diff --check`.

## Checklist

- [x] I read the [contributing guidelines](https://github.com/TheWidlarzGroup/react-native-video/blob/master/CONTRIBUTING.md).
- [x] I updated the documentation / README where relevant. No update is required because this restores an existing source type and does not change usage.
- [x] If this changes how the library is used (API, props, events, behavior), I updated the AI agent skill (`skills/react-native-video/`) to match. No update is required because the public usage remains unchanged.
- [x] This PR is focused on a single concern.
- [x] I tested my changes on at least one platform.