### PR TITLE
fix(android): make muted assignments idempotent

### DIFF
--- a/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
@@ -167,6 +167,8 @@ class HybridVideoPlayer() : HybridVideoPlayerSpec(), AutoCloseable {
       return@mainThreadProperty playerVolume == 0.0
     },
     set = { value ->
+      if (value == muted) return@mainThreadProperty
+
       if (value) {
         userVolume = volume
         player.volume = 0f


### PR DESCRIPTION
## Summary

Make Android `muted` assignments idempotent so repeated assignments preserve the volume that should be restored when unmuting.

## Motivation

On Android, a second `muted = true` assignment currently stores the already-muted player volume (`0`) in `userVolume`. A subsequent `muted = false` therefore restores `0`, so playback remains silent.

Fixes #5043.

## Changes

- Return early when the requested muted value already matches the actual player state.
- Preserve the pre-mute `userVolume`.
- Avoid duplicate `onVolumeChange` events when no mute state transition occurs.

## Platforms affected

- [x] Android
- [ ] iOS
- [ ] visionOS
- [ ] tvOS / Android TV
- [ ] Windows
- [ ] Web

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only

## Test plan

Applied the change to `react-native-video@7.0.0-beta.11` and verified it in a bare React Native app using React Native 0.81.5, `react-native-nitro-modules` 0.35.0, and the New Architecture.

Tested on:

- Android 12, Samsung Galaxy Fold 5G (SM-F907N), real device
- Android 16, Samsung Galaxy A33 5G (SM-A336N), real device

Before the change:

1. Initialize the player with `muted = true`.
2. Assign `muted = true` again.
3. Assign `muted = false`.
4. Playback remains silent because `userVolume` was overwritten with `0`.

After the change:

- Initial playback remains muted.
- The first unmute restores speaker output.
- Repeated mute/unmute transitions continue to restore the volume.
- Re-entering the page preserves the same behavior.
- No regression was observed in existing playback behavior.

## Checklist

- [x] I read the [contributing guidelines](https://github.com/TheWidlarzGroup/react-native-video/blob/master/CONTRIBUTING.md).
- [x] I updated the documentation / README where relevant. (Not applicable: there is no public API or usage change.)
- [x] If this changes how the library is used (API, props, events, behavior), I updated the AI agent skill (`skills/react-native-video/`) to match. (Not applicable: this restores the existing `muted` behavior.)
- [x] This PR is focused on a single concern.
- [x] I tested my changes on at least one platform.