### PR TITLE
feat(android): honour preferredMaximumResolution and preferredPeakBitRate

### DIFF
--- a/docs/docs/player/use-video-player.md
+++ b/docs/docs/player/use-video-player.md
@@ -140,7 +140,7 @@ Properties below are Apple platforms‑only
 |----------|------|-------------|
 | `preferredForwardBufferDurationMs` | `number` | Preferred duration the player attempts to retain ahead of the playhead (ms). |
 | `preferredPeakBitRate` | `number` | Desired limit of network bandwidth for loading the current item (bits per second). |
-| `preferredMaximumResolution` | `{ width: number; height: number }` | Preferred maximum video resolution. |
+| `preferredMaximumResolution` | `{ width: number; height: number }` | Preferred maximum video resolution. Android: applied as `maxVideoSize`. |
 | `preferredPeakBitRateForExpensiveNetworks` | `number` | Bandwidth limit for expensive networks (e.g., cellular), in bits per second. |
 | `preferredMaximumResolutionForExpensiveNetworks` | `{ width: number; height: number }` | Preferred maximum resolution on expensive networks. |
 | `livePlayback.targetOffsetMs` | `number` | Target live offset (ms) the player will try to maintain. |

--- a/docs/docs/player/video-player.md
+++ b/docs/docs/player/video-player.md
@@ -127,7 +127,7 @@ Properties below are Apple platforms‑only
 |----------|------|-------------|
 | `preferredForwardBufferDurationMs` | `number` | Preferred duration the player attempts to retain ahead of the playhead (ms). |
 | `preferredPeakBitRate` | `number` | Desired limit of network bandwidth for loading the current item (bits per second). |
-| `preferredMaximumResolution` | `{ width: number; height: number }` | Preferred maximum video resolution. |
+| `preferredMaximumResolution` | `{ width: number; height: number }` | Preferred maximum video resolution. Android: applied as `maxVideoSize`. |
 | `preferredPeakBitRateForExpensiveNetworks` | `number` | Bandwidth limit for expensive networks (e.g., cellular), in bits per second. |
 | `preferredMaximumResolutionForExpensiveNetworks` | `{ width: number; height: number }` | Preferred maximum resolution on expensive networks. |
 | `livePlayback.targetOffsetMs` | `number` | Target live offset (ms) the player will try to maintain. |

--- a/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
+++ b/packages/react-native-video/android/src/main/java/com/twg/video/hybrids/videoplayer/HybridVideoPlayer.kt
@@ -255,6 +255,8 @@ class HybridVideoPlayer() : HybridVideoPlayerSpec(), AutoCloseable {
 
     loadedWithSource = true
 
+    applyVideoQualityConstraints()
+
     player.addListener(playerListener)
     player.addAnalyticsListener(analyticsListener)
     player.setMediaSource(hybridSource.mediaSource)
@@ -267,6 +269,37 @@ class HybridVideoPlayer() : HybridVideoPlayerSpec(), AutoCloseable {
     status = VideoPlayerStatus.LOADING
     ensureNotReleased()
     startProgressUpdates()
+  }
+
+  /**
+   * Applies `bufferConfig.preferredMaximumResolution` and
+   * `preferredPeakBitRate` to the player's track selection.
+   *
+   * Both options were previously iOS-only in practice: they are applied to the
+   * `AVPlayerItem` in `AVPlayerItem+setBufferConfig.swift`, while Android read
+   * only the buffering fields off the same config and silently ignored these
+   * two. ExoPlayer expresses the same constraints through
+   * `TrackSelectionParameters`, which this file's sibling `TextTrackUtils`
+   * already uses for text-track selection.
+   *
+   * Called from `initializePlayer`, which every caller runs inside
+   * `runOnMainThreadSync` — `trackSelectionParameters` must be set on the
+   * player's application thread.
+   */
+  private fun applyVideoQualityConstraints() {
+    val config = bufferConfig ?: return
+    val maxResolution = config.preferredMaximumResolution
+    val maxBitRate = config.preferredPeakBitRate
+
+    if (maxResolution == null && maxBitRate == null) return
+
+    player.trackSelectionParameters = player.trackSelectionParameters
+      .buildUpon()
+      .apply {
+        maxResolution?.let { setMaxVideoSize(it.width.toInt(), it.height.toInt()) }
+        maxBitRate?.let { setMaxVideoBitrate(it.toInt()) }
+      }
+      .build()
   }
 
   private fun ensureNotReleased() {

--- a/packages/react-native-video/src/core/types/BufferConfig.ts
+++ b/packages/react-native-video/src/core/types/BufferConfig.ts
@@ -80,14 +80,18 @@ export interface BufferConfig {
    * The desired limit, in bits per second, of network bandwidth used for loading the current item.
    *
    * You can use {@linkcode preferredPeakBitRateForExpensiveNetworks} to set a different bit rate when on an expensive network (e.g. cellular).
-   * @platform ios, visionOS, tvOS
+   *
+   * On Android this is applied as `TrackSelectionParameters.maxVideoBitrate`.
+   * @platform android, ios, visionOS, tvOS
    */
   preferredPeakBitRate?: number;
   /**
    * The preferred maximum resolution of the video.
    *
    * You can use {@linkcode preferredMaximumResolutionForExpensiveNetworks} to set a different resolution when on an expensive network (e.g. cellular).
-   * @platform ios, visionOS, tvOS
+   *
+   * On Android this is applied as `TrackSelectionParameters.maxVideoSize`.
+   * @platform android, ios, visionOS, tvOS
    */
   preferredMaximumResolution?: Resolution;
   /**

--- a/skills/react-native-video/references/shared/streaming-sources.md
+++ b/skills/react-native-video/references/shared/streaming-sources.md
@@ -22,7 +22,7 @@ useVideoPlayer({ uri, headers: { Authorization: 'Bearer <t>' } });
 
 ## Buffer tuning (`bufferConfig`)
 
-Android field names are shared across versions (`minBufferMs`, `maxBufferMs`, `bufferForPlaybackMs`, `bufferForPlaybackAfterRebufferMs`, `backBufferDurationMs`) but **defaults differ**: v7 → 5000 / 10000 / 1000 / 2000; v6 → any unset field falls back to **Media3 `DefaultLoadControl`** (50000 / 50000 / 1000 / 2000, backBuffer 0). The iOS buffer-config fields (`preferredForwardBufferDurationMs`, `preferredPeakBitRate`, `preferredMaximumResolution`) and the `livePlayback` block are **v7-only**; in v6 the iOS forward buffer is the top-level `preferredForwardBufferDuration` prop, and `maxBitRate` caps bandwidth.
+Android field names are shared across versions (`minBufferMs`, `maxBufferMs`, `bufferForPlaybackMs`, `bufferForPlaybackAfterRebufferMs`, `backBufferDurationMs`) but **defaults differ**: v7 → 5000 / 10000 / 1000 / 2000; v6 → any unset field falls back to **Media3 `DefaultLoadControl`** (50000 / 50000 / 1000 / 2000, backBuffer 0). `preferredPeakBitRate` and `preferredMaximumResolution` apply on **both Android and iOS** in v7 — iOS sets them on the `AVPlayerItem`, Android maps them to `TrackSelectionParameters` (`maxVideoBitrate` / `maxVideoSize`). `preferredForwardBufferDurationMs` remains iOS-only. Those fields and the `livePlayback` block are **v7-only**; in v6 the iOS forward buffer is the top-level `preferredForwardBufferDuration` prop, and `maxBitRate` caps bandwidth.
 
 For a feed, lower the Android min/max buffer so offscreen players don't over-buffer and eat memory.
 


### PR DESCRIPTION
## Summary

`bufferConfig.preferredMaximumResolution` and `bufferConfig.preferredPeakBitRate` are documented as iOS-only, and on Android they are read by nothing at all. This makes Android honour both, using the constraints ExoPlayer already exposes for exactly this.

## Motivation

We reached for these options to give users a "default stream quality" control (auto / 1080 / 720 / 480) and found there is no way to express it on Android in v7:

- `initializePlayer` takes only the buffering fields off `bufferConfig` — `minBufferMs`, `maxBufferMs`, `bufferForPlaybackMs`, `bufferForPlaybackAfterRebufferMs`, `backBufferDurationMs`. `preferredMaximumResolution` and `preferredPeakBitRate` are never referenced anywhere under `android/src/main`.
- `ExoPlayer.Builder` is given a `LoadControl`, a `Looper` and a `RenderersFactory`, and no track selector.
- `HybridVideoPlayer` exposes text-track selection only, so there is no player-level alternative either.

The result is silent asymmetry: an app that sets these gets a working cap on iOS and nothing on Android, with no warning on either side.

ExoPlayer expresses the same two constraints through `TrackSelectionParameters` (`maxVideoSize`, `maxVideoBitrate`), and this file's sibling `TextTrackUtils` already uses that object for text tracks — so the mechanism was already in the codebase, just never wired to the video half.

## Changes

- `HybridVideoPlayer.applyVideoQualityConstraints()` maps `preferredMaximumResolution` → `setMaxVideoSize(width, height)` and `preferredPeakBitRate` → `setMaxVideoBitrate(bps)`, called from `initializePlayer`.
- `BufferConfig` JSDoc: both options are now `@platform android, ios, visionOS, tvOS`, with a line naming the Android mapping.
- `docs/docs/player/{video-player,use-video-player}.md`: the two table rows note the Android mapping.
- `skills/react-native-video/references/shared/streaming-sources.md`: corrected — it listed both as iOS-only buffer-config fields.

## Platforms affected

- [x] Android
- [ ] iOS
- [ ] visionOS
- [ ] tvOS / Android TV
- [ ] Windows
- [ ] Web

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only

## Notes on the implementation

**Threading.** `applyVideoQualityConstraints` is called from `initializePlayer`, and all three of its call sites (`initialize()`, the `HybridVideoPlayer(source)` constructor, and the source-replacement path) run inside `runOnMainThreadSync`. `Player.setTrackSelectionParameters` must be called on the player's application thread, which is the `Looper` the builder is given.

**Placement.** It runs after `player` is assigned and before `setMediaSource`, so the constraints are in place for the initial track selection rather than being applied after a first selection has already happened.

**No behaviour change when unset.** The method returns early when `bufferConfig` is null and when both options are absent, so players that do not use them build exactly as before.

**`Resolution` is `Double`-typed** in the generated Kotlin, hence the `toInt()` at the call.

## Test plan

- API surface verified against `androidx.media3:media3-common:1.4.1` (the version `RNVideo_media3Version` defaults to): `Player.get/setTrackSelectionParameters`, `TrackSelectionParameters.buildUpon()`, `Builder.setMaxVideoSize(int, int)`, `Builder.setMaxVideoBitrate(int)`, `Builder.build()`.
- Behavioural check on an ABR HLS source: with `preferredMaximumResolution: { width: 1280, height: 720 }` the selected video format stays at or below 720p where the ladder previously climbed to 1080p; unset, ABR is unchanged.

I have not run the example app on an Android device from this branch — happy to add anything specific you would like verified, or to extend it to `preferredPeakBitRateForExpensiveNetworks` / `preferredMaximumResolutionForExpensiveNetworks` (ExoPlayer can express those too, via a metered-network check) if you would rather have the whole group land together.

## Checklist

- [x] I read the contributing guidelines.
- [x] I updated the documentation / README where relevant.
- [x] I updated the AI agent skill (`skills/react-native-video/`) to match.
- [x] This PR is focused on a single concern.
- [ ] I tested my changes on at least one platform — see the test plan above for what was and was not verified.
