### PR TITLE
fix(web): respect resizeMode prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "docs:llms-full": "node scripts/generate-llms-full.js",
         "release": "release-it",
         "test": "echo no test available",
+        "test:web": "yarn build && node --test tests/Video.web.test.mjs",
         "check-ios": "scripts/swift-format.sh && scripts/swift-lint.sh && scripts/clang-format.sh",
         "check-android": "scripts/kotlin-lint.sh",
         "check-all": "yarn check-android; yarn check-ios; yarn lint",

--- a/src/Video.web.tsx
+++ b/src/Video.web.tsx
@@ -54,6 +54,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       rate,
       repeat,
       controls,
+      resizeMode = 'none',
       showNotificationControls = false,
       poster,
       fullscreen,
@@ -429,7 +430,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
           onVolumeChange?.({volume: nativeRef.current.volume});
         }}
         onEnded={onEnd}
-        style={[videoStyle, style]}
+        style={[videoStyle, videoResizeModeStyles[resizeMode], style]}
       />
     );
   },
@@ -442,6 +443,16 @@ const videoStyle = {
   width: '100%',
   height: '100%',
 } satisfies React.CSSProperties;
+
+const videoResizeModeStyles = {
+  contain: {objectFit: 'contain'},
+  cover: {objectFit: 'cover'},
+  none: {objectFit: 'contain'},
+  stretch: {objectFit: 'fill'},
+} satisfies Record<
+  NonNullable<ReactVideoProps['resizeMode']>,
+  React.CSSProperties
+>;
 
 const useMediaSession = (
   metadata: VideoMetadata | undefined,

--- a/tests/Video.web.test.mjs
+++ b/tests/Video.web.test.mjs
@@ -1,0 +1,41 @@
+/* global globalThis */
+
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import React from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+import videoModule from '../lib/Video.web.js';
+
+Object.defineProperty(globalThis, 'navigator', {
+  configurable: true,
+  value: {},
+});
+
+const Video = videoModule.default;
+
+const renderVideo = (resizeMode) =>
+  renderToStaticMarkup(
+    React.createElement(Video, {
+      paused: true,
+      resizeMode,
+      source: {uri: 'video.mp4'},
+    }),
+  );
+
+describe('Video web resizeMode', () => {
+  const cases = [
+    ['contain', 'contain'],
+    ['cover', 'cover'],
+    ['stretch', 'fill'],
+    ['none', 'contain'],
+  ];
+
+  for (const [resizeMode, objectFit] of cases) {
+    it(`maps ${resizeMode} to object-fit: ${objectFit}`, () => {
+      assert.match(
+        renderVideo(resizeMode),
+        new RegExp(`object-fit:${objectFit}`),
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #4297.

### Motivation

The v6 web renderer always applied `object-fit: contain` to the underlying `<video>`, so the public `resizeMode` prop had no effect in browsers. The v7 renderer already maps these values to CSS; this ports that behavior to the supported v6 branch.

### Changes

- map `contain` to `object-fit: contain`
- map `cover` to `object-fit: cover`
- map `stretch` to `object-fit: fill`
- preserve the existing `none` fallback as `object-fit: contain`
- add a built-output regression test for all four resize modes

The mapping uses static style objects and keeps the existing user `style` last in the style array, preserving v6 web override behavior.

## Test plan

- Red: `yarn test:web` failed because `resizeMode="cover"` still rendered `object-fit:contain`.
- Green: `yarn test:web` passes (TypeScript build + 4/4 Node DOM-render tests).
- `yarn lint` passes.
- `git diff --check` passes.