### PR TITLE
fix(android): annotate manifest track lookup worker thread

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1607,6 +1607,7 @@ public class ReactExoplayerView extends FrameLayout implements
         return videoTracks;
     }
 
+    @WorkerThread
     private ArrayList<VideoTrack> getVideoTrackInfoFromManifest() {
         return this.getVideoTrackInfoFromManifest(0);
     }


### PR DESCRIPTION
## Summary

Fixes #4885.

### Motivation

The retrying `getVideoTrackInfoFromManifest(int)` overload is correctly annotated with `@WorkerThread`, but its zero-argument wrapper was not. Android lint therefore inferred the wrapper as a UI-thread method and rejected its call into the worker-only overload, even though the production call site runs inside `ExecutorService.execute`.

### Changes

- annotate the zero-argument wrapper with the same `@WorkerThread` contract
- keep runtime behavior unchanged; this documents the existing background-thread requirement instead of suppressing `WrongThread`

## Test plan

Created a clean React Native 0.85.0 project matching the issue and installed this branch as the local `react-native-video` package.

- Red, before the annotation:
  - `./gradlew :react-native-video:lintDebug --no-daemon`
  - failed with exactly one lint error at `ReactExoplayerView.java:1611`: `getVideoTrackInfoFromManifest must be called from the worker thread`
- Green, after the annotation:
  - the same Gradle 9.3.1 lint command completed with `BUILD SUCCESSFUL`
- `yarn build`
- `yarn lint`
- `git diff --check`